### PR TITLE
Add AppVeyor CI configuration file

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,5 +1,5 @@
 build_script:
-        - ps: "cd ..\\..; move projects\\orangec .; cd orangec\\src; .\\ms; cd ..; move orangec projects"
+        - ps: "cd ..\\..; move projects\\orangec .; cd orangec\\src; .\\ms; cd ..\\..; move orangec projects"
 
 artifacts:
   - path: "src\\Release\\ocpp.exe"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,37 +2,37 @@ build_script:
         - ps: "cd ..\\..; move projects\\orangec .; cd orangec\\src; .\\ms"
 
 artifacts:
-  - path: "..\\orangec\\src\\Release\\ocpp.exe"
+  - path: "\\orangec\\src\\Release\\ocpp.exe"
     name: ocpp
-  - path: "..\\orangec\\src\\Release\\ocide.exe"
+  - path: "\\orangec\\src\\Release\\ocide.exe"
     name: ocide
-  - path: "..\\orangec\\src\\Release\\occpr.exe"
+  - path: "\\orangec\\src\\Release\\occpr.exe"
     name: occpr
-  - path: "..\\orangec\\src\\Release\\occ.exe"
+  - path: "\\orangec\\src\\Release\\occ.exe"
     name: occ
-  - path: "..\\orangec\\src\\Release\\coff2ieee.exe"
+  - path: "\\orangec\\src\\Release\\coff2ieee.exe"
     name: coff2ieee
-  - path: "..\\orangec\\src\\Release\\omake.exe"
+  - path: "\\orangec\\src\\Release\\omake.exe"
     name: omake
-  - path: "..\\orangec\\src\\Release\\oimplib.exe"
+  - path: "\\orangec\\src\\Release\\oimplib.exe"
     name: oimplib
-  - path: "..\\orangec\\src\\Release\\obrc.exe"
+  - path: "\\orangec\\src\\Release\\obrc.exe"
     name: obrc
-  - path: "..\\orangec\\src\\Release\\ogrep.exe"
+  - path: "\\orangec\\src\\Release\\ogrep.exe"
     name: ogrep
-  - path: "..\\orangec\\src\\Release\\dplm.exe"
+  - path: "\\orangec\\src\\Release\\dplm.exe"
     name: dplm
-  - path: "..\\orangec\\src\\Release\\dple.exe"
+  - path: "\\orangec\\src\\Release\\dple.exe"
     name: dple
-  - path: "..\\orangec\\src\\Release\\dlmz.exe"
+  - path: "\\orangec\\src\\Release\\dlmz.exe"
     name: dlmz
-  - path: "..\\orangec\\src\\Release\\dlle.exe"
+  - path: "\\orangec\\src\\Release\\dlle.exe"
     name: dlle
-  - path: "..\\orangec\\src\\Release\\dlhex.exe"
+  - path: "\\orangec\\src\\Release\\dlhex.exe"
     name: dlhex
-  - path: "..\\orangec\\src\\Release\\olib.exe"
+  - path: "\\orangec\\src\\Release\\olib.exe"
     name: olib
-  - path: "..\\orangec\\src\\Release\\olink.exe"
+  - path: "\\orangec\\src\\Release\\olink.exe"
     name: olink
-  - path: "..\\orangec\\src\\Release\\oasm.exe"
+  - path: "\\orangec\\src\\Release\\oasm.exe"
     name: oasm

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,5 +1,5 @@
 build_script:
-        - ps: "cd ..\\..; move projects\\orangec .; cd orangec\\src; msbuild /Property:configuration=Release /Property:platform=win32; .\\omake fullbuild"
+        - ps: "cd ..\\..; move projects\\orangec .; cd orangec\\src; .\\ms; .\\Release\\omake fullbuild"
 
 artifacts:
   - path: "orangec\\src\\Release\\ocpp.exe"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,2 +1,38 @@
 build_script:
-        - ps: "cd src; msbuild /Property:configuration=Release /Property:platform=win32; omake fullbuild"
+        - ps: "cd ..\\..; move project\\orangec .; cd orangec\\src; msbuild /Property:configuration=Release /Property:platform=win32; .\\omake fullbuild"
+
+artifacts:
+  - path: "orangec\\src\\Release\\ocpp.exe"
+    name: ocpp
+  - path: "orangec\\src\\Release\\ocide.exe"
+    name: ocide
+  - path: "orangec\\src\\Release\\occpr.exe"
+    name: occpr
+  - path: "orangec\\src\\Release\\occ.exe"
+    name: occ
+  - path: "orangec\\src\\Release\\coff2ieee.exe"
+    name: coff2ieee
+  - path: "orangec\\src\\Release\\omake.exe"
+    name: omake
+  - path: "orangec\\src\\Release\\oimplib.exe"
+    name: oimplib
+  - path: "orangec\\src\\Release\\obrc.exe"
+    name: obrc
+  - path: "orangec\\src\\Release\\ogrep.exe"
+    name: ogrep
+  - path: "orangec\\src\\Release\\dplm.exe"
+    name: dplm
+  - path: "orangec\\src\\Release\\dple.exe"
+    name: dple
+  - path: "orangec\\src\\Release\\dlmz.exe"
+    name: dlmz
+  - path: "orangec\\src\\Release\\dlle.exe"
+    name: dlle
+  - path: "orangec\\src\\Release\\dlhex.exe"
+    name: dlhex
+  - path: "orangec\\src\\Release\\olib.exe"
+    name: olib
+  - path: "orangec\\src\\Release\\olink.exe"
+    name: olink
+  - path: "orangec\\src\\Release\\oasm.exe"
+    name: oasm

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,2 @@
+build_script:
+        - ps: "msbuild /Property:configuration=Release /Property:platform=win32; omake fullbuild"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,2 +1,2 @@
 build_script:
-        - ps: "msbuild /Property:configuration=Release /Property:platform=win32; omake fullbuild"
+        - ps: "cd src; msbuild /Property:configuration=Release /Property:platform=win32; omake fullbuild"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,5 +1,5 @@
 build_script:
-        - ps: "cd ..\\..; move project\\orangec .; cd orangec\\src; msbuild /Property:configuration=Release /Property:platform=win32; .\\omake fullbuild"
+        - ps: "cd ..\\..; move projects\\orangec .; cd orangec\\src; msbuild /Property:configuration=Release /Property:platform=win32; .\\omake fullbuild"
 
 artifacts:
   - path: "orangec\\src\\Release\\ocpp.exe"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,38 +1,38 @@
 build_script:
-        - ps: "cd ..\\..; move projects\\orangec .; cd orangec\\src; .\\ms; .\\Release\\omake fullbuild"
+        - ps: "cd ..\\..; move projects\\orangec .; cd orangec\\src; .\\ms"
 
 artifacts:
-  - path: "orangec\\src\\Release\\ocpp.exe"
+  - path: "..\\orangec\\src\\Release\\ocpp.exe"
     name: ocpp
-  - path: "orangec\\src\\Release\\ocide.exe"
+  - path: "..\\orangec\\src\\Release\\ocide.exe"
     name: ocide
-  - path: "orangec\\src\\Release\\occpr.exe"
+  - path: "..\\orangec\\src\\Release\\occpr.exe"
     name: occpr
-  - path: "orangec\\src\\Release\\occ.exe"
+  - path: "..\\orangec\\src\\Release\\occ.exe"
     name: occ
-  - path: "orangec\\src\\Release\\coff2ieee.exe"
+  - path: "..\\orangec\\src\\Release\\coff2ieee.exe"
     name: coff2ieee
-  - path: "orangec\\src\\Release\\omake.exe"
+  - path: "..\\orangec\\src\\Release\\omake.exe"
     name: omake
-  - path: "orangec\\src\\Release\\oimplib.exe"
+  - path: "..\\orangec\\src\\Release\\oimplib.exe"
     name: oimplib
-  - path: "orangec\\src\\Release\\obrc.exe"
+  - path: "..\\orangec\\src\\Release\\obrc.exe"
     name: obrc
-  - path: "orangec\\src\\Release\\ogrep.exe"
+  - path: "..\\orangec\\src\\Release\\ogrep.exe"
     name: ogrep
-  - path: "orangec\\src\\Release\\dplm.exe"
+  - path: "..\\orangec\\src\\Release\\dplm.exe"
     name: dplm
-  - path: "orangec\\src\\Release\\dple.exe"
+  - path: "..\\orangec\\src\\Release\\dple.exe"
     name: dple
-  - path: "orangec\\src\\Release\\dlmz.exe"
+  - path: "..\\orangec\\src\\Release\\dlmz.exe"
     name: dlmz
-  - path: "orangec\\src\\Release\\dlle.exe"
+  - path: "..\\orangec\\src\\Release\\dlle.exe"
     name: dlle
-  - path: "orangec\\src\\Release\\dlhex.exe"
+  - path: "..\\orangec\\src\\Release\\dlhex.exe"
     name: dlhex
-  - path: "orangec\\src\\Release\\olib.exe"
+  - path: "..\\orangec\\src\\Release\\olib.exe"
     name: olib
-  - path: "orangec\\src\\Release\\olink.exe"
+  - path: "..\\orangec\\src\\Release\\olink.exe"
     name: olink
-  - path: "orangec\\src\\Release\\oasm.exe"
+  - path: "..\\orangec\\src\\Release\\oasm.exe"
     name: oasm

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,38 +1,38 @@
 build_script:
-        - ps: "cd ..\\..; move projects\\orangec .; cd orangec\\src; .\\ms"
+        - ps: "cd ..\\..; move projects\\orangec .; cd orangec\\src; .\\ms; cd ..; move orangec projects"
 
 artifacts:
-  - path: "\\orangec\\src\\Release\\ocpp.exe"
+  - path: "src\\Release\\ocpp.exe"
     name: ocpp
-  - path: "\\orangec\\src\\Release\\ocide.exe"
+  - path: "src\\Release\\ocide.exe"
     name: ocide
-  - path: "\\orangec\\src\\Release\\occpr.exe"
+  - path: "src\\Release\\occpr.exe"
     name: occpr
-  - path: "\\orangec\\src\\Release\\occ.exe"
+  - path: "src\\Release\\occ.exe"
     name: occ
-  - path: "\\orangec\\src\\Release\\coff2ieee.exe"
+  - path: "src\\Release\\coff2ieee.exe"
     name: coff2ieee
-  - path: "\\orangec\\src\\Release\\omake.exe"
+  - path: "src\\Release\\omake.exe"
     name: omake
-  - path: "\\orangec\\src\\Release\\oimplib.exe"
+  - path: "src\\Release\\oimplib.exe"
     name: oimplib
-  - path: "\\orangec\\src\\Release\\obrc.exe"
+  - path: "src\\Release\\obrc.exe"
     name: obrc
-  - path: "\\orangec\\src\\Release\\ogrep.exe"
+  - path: "src\\Release\\ogrep.exe"
     name: ogrep
-  - path: "\\orangec\\src\\Release\\dplm.exe"
+  - path: "src\\Release\\dplm.exe"
     name: dplm
-  - path: "\\orangec\\src\\Release\\dple.exe"
+  - path: "src\\Release\\dple.exe"
     name: dple
-  - path: "\\orangec\\src\\Release\\dlmz.exe"
+  - path: "src\\Release\\dlmz.exe"
     name: dlmz
-  - path: "\\orangec\\src\\Release\\dlle.exe"
+  - path: "src\\Release\\dlle.exe"
     name: dlle
-  - path: "\\orangec\\src\\Release\\dlhex.exe"
+  - path: "src\\Release\\dlhex.exe"
     name: dlhex
-  - path: "\\orangec\\src\\Release\\olib.exe"
+  - path: "src\\Release\\olib.exe"
     name: olib
-  - path: "\\orangec\\src\\Release\\olink.exe"
+  - path: "src\\Release\\olink.exe"
     name: olink
-  - path: "\\orangec\\src\\Release\\oasm.exe"
+  - path: "src\\Release\\oasm.exe"
     name: oasm


### PR DESCRIPTION
Hi again David,

With this file merged, and after a trivial signup procedure at http://appveyor.com, AppVeyor can automatically build every commit and artifact the resulting executables.

For example, here are some executables resulting from a build of the current master branch: https://ci.appveyor.com/project/ysangkok/orangec/build/artifacts

The project I have configured will only built my own fork, this is why I made this pull request.

I don't see any disadvantages to enabling this. AppVeyor will send you an email after each build by default, but it is easy to disable this.

Regards,
Janus