### PR TITLE
Adding clang as a compiler to build from on APPVEYOR

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,6 +12,7 @@ environment:
   matrix:
     - BUILD_PROFILE: MINGW64
     - BUILD_PROFILE: MS
+    - BUILD_PROFILE: CLANG
  
 build_script:
 # the appveyor virtual machine reported two processors, so, lets try running parallel compile!

--- a/src/ocide/HEADER.H
+++ b/src/ocide/HEADER.H
@@ -865,7 +865,7 @@ typedef struct tagNMTTCUSTOMDRAW
     (*(HTREEITEM FAR *)prc = (hitem), (BOOL)SendMessage((hwnd), TVM_GETITEMRECT, (WPARAM)(code), (LPARAM)(RECT FAR*)(prc)))
 #endif
 
-#if defined(__MINGW64__) || defined(__clang__)
+#if defined(__MINGW64__)
 #define Eax Rax
 #define Ebx Rbx
 #define Ecx Rdx


### PR DESCRIPTION
There's no reason this PR shouldn't work except that if clang has more problems than GCC on windows (which it probably does, but we'll find out about that, now won't we). I essentially just copy/pasted from the MINGW64 makefile to edit it up so that it hopefully works properly. Once we can get the warnings all in from clang, gcc, and MSVC that should be a lot of items we could fix and hopefully get less confusing things to happen with.

(this PR is about #148 )