### PR TITLE
This is for some minor issues I found in alloc

### DIFF
--- a/src/clibs/alloc/aalloc.c
+++ b/src/clibs/alloc/aalloc.c
@@ -1,47 +1,47 @@
 /* Software License Agreement
- * 
+ *
  *     Copyright(C) 1994-2018 David Lindauer, (LADSoft)
- * 
+ *
  *     This file is part of the Orange C Compiler package.
- * 
+ *
  *     The Orange C Compiler package is free software: you can redistribute it and/or modify
  *     it under the terms of the GNU General Public License as published by
  *     the Free Software Foundation, either version 3 of the License, or
- *     (at your option) any later version, with the addition of the 
+ *     (at your option) any later version, with the addition of the
  *     Orange C "Target Code" exception.
- * 
+ *
  *     The Orange C Compiler package is distributed in the hope that it will be useful,
  *     but WITHOUT ANY WARRANTY; without even the implied warranty of
  *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  *     GNU General Public License for more details.
- * 
+ *
  *     You should have received a copy of the GNU General Public License
  *     along with Orange C.  If not, see <http://www.gnu.org/licenses/>.
- * 
+ *
  *     contact information:
  *         email: TouchStone222@runbox.com <David Lindauer>
- * 
+ *
  */
 
 #include <stdlib.h>
 #include <string.h>
 
-void *_RTL_FUNC aligned_alloc(size_t __align, size_t __size)
+void* _RTL_FUNC aligned_alloc(size_t __align, size_t __size)
 {
     // this is brute force and uses too much memory...
     // i don't have time to rewrite the entire allocation algorithm though...
     size_t sz = __align + __size;
-    void *t = malloc(sz);
+    void* t = malloc(sz);
     if (t)
     {
         int ofs = (unsigned)t % __align;
         if (ofs)
         {
             ofs = __align - ofs;
-            t = (char *)t + ofs;
-            *(unsigned *)((char *)t-sizeof(unsigned)) = - ofs; /// stuff in a negative value into what would normally
-                                                                // be the size field, to signify this
-                                                                // was aligned to free()
+            t = (char*)t + ofs;
+            *(unsigned*)((char*)t - sizeof(unsigned)) = -ofs;  /// stuff in a negative value into what would normally
+                                                               // be the size field, to signify this
+                                                               // was aligned to free()
         }
     }
     return t;

--- a/src/clibs/alloc/aalloc.c
+++ b/src/clibs/alloc/aalloc.c
@@ -30,7 +30,7 @@ void *_RTL_FUNC aligned_alloc(size_t __align, size_t __size)
 {
     // this is brute force and uses too much memory...
     // i don't have time to rewrite the entire allocation algorithm though...
-    int sz = __align + __size;
+    size_t sz = __align + __size;
     void *t = malloc(sz);
     if (t)
     {

--- a/src/clibs/alloc/calloc.c
+++ b/src/clibs/alloc/calloc.c
@@ -1,36 +1,36 @@
 /* Software License Agreement
- * 
+ *
  *     Copyright(C) 1994-2018 David Lindauer, (LADSoft)
- * 
+ *
  *     This file is part of the Orange C Compiler package.
- * 
+ *
  *     The Orange C Compiler package is free software: you can redistribute it and/or modify
  *     it under the terms of the GNU General Public License as published by
  *     the Free Software Foundation, either version 3 of the License, or
- *     (at your option) any later version, with the addition of the 
+ *     (at your option) any later version, with the addition of the
  *     Orange C "Target Code" exception.
- * 
+ *
  *     The Orange C Compiler package is distributed in the hope that it will be useful,
  *     but WITHOUT ANY WARRANTY; without even the implied warranty of
  *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  *     GNU General Public License for more details.
- * 
+ *
  *     You should have received a copy of the GNU General Public License
  *     along with Orange C.  If not, see <http://www.gnu.org/licenses/>.
- * 
+ *
  *     contact information:
  *         email: TouchStone222@runbox.com <David Lindauer>
- * 
+ *
  */
 
 #include <stdlib.h>
 #include <string.h>
 
-void *_RTL_FUNC calloc(size_t numelms, size_t elmsize)
+void* _RTL_FUNC calloc(size_t numelms, size_t elmsize)
 {
     size_t size = numelms * elmsize;
-    void *pos = malloc(size);
+    void* pos = malloc(size);
     if (pos)
-        memset(pos,0,size);
+        memset(pos, 0, size);
     return pos;
 }

--- a/src/clibs/alloc/calloc.c
+++ b/src/clibs/alloc/calloc.c
@@ -28,9 +28,8 @@
 
 void *_RTL_FUNC calloc(size_t numelms, size_t elmsize)
 {
-    unsigned size = numelms * elmsize;
-    void *pos;
-    pos = malloc(size);
+    size_t size = numelms * elmsize;
+    void *pos = malloc(size);
     if (pos)
         memset(pos,0,size);
     return pos;

--- a/src/clibs/alloc/farmem.c
+++ b/src/clibs/alloc/farmem.c
@@ -1,26 +1,26 @@
 /* Software License Agreement
- * 
+ *
  *     Copyright(C) 1994-2018 David Lindauer, (LADSoft)
- * 
+ *
  *     This file is part of the Orange C Compiler package.
- * 
+ *
  *     The Orange C Compiler package is free software: you can redistribute it and/or modify
  *     it under the terms of the GNU General Public License as published by
  *     the Free Software Foundation, either version 3 of the License, or
- *     (at your option) any later version, with the addition of the 
+ *     (at your option) any later version, with the addition of the
  *     Orange C "Target Code" exception.
- * 
+ *
  *     The Orange C Compiler package is distributed in the hope that it will be useful,
  *     but WITHOUT ANY WARRANTY; without even the implied warranty of
  *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  *     GNU General Public License for more details.
- * 
+ *
  *     You should have received a copy of the GNU General Public License
  *     along with Orange C.  If not, see <http://www.gnu.org/licenses/>.
- * 
+ *
  *     contact information:
  *         email: TouchStone222@runbox.com <David Lindauer>
- * 
+ *
  */
 
 #include <stdio.h>
@@ -33,30 +33,35 @@
 #include <dpmi.h>
 #include <dos.h>
 
-void far *_RTL_FUNC farmalloc(size_t size)
+void far* _RTL_FUNC farmalloc(size_t size)
 {
-   SELECTOR seg=0 ;
-   void *s = malloc(size) ;
-   if (s) {
-      if (!dpmi_alloc_descriptors(&seg,1)) {
-         dpmi_set_sel_access_rights(seg,0xc092) ;
-         dpmi_set_sel_limit(seg, size-1) ;
-         dpmi_set_sel_base(seg, (ULONG)s) ;
-      } else {
-         seg = 0 ;
-         free(s) ;
-      }
-   }
-   return MK_FP(seg,0) ;
+    SELECTOR seg = 0;
+    void* s = malloc(size);
+    if (s)
+    {
+        if (!dpmi_alloc_descriptors(&seg, 1))
+        {
+            dpmi_set_sel_access_rights(seg, 0xc092);
+            dpmi_set_sel_limit(seg, size - 1);
+            dpmi_set_sel_base(seg, (ULONG)s);
+        }
+        else
+        {
+            seg = 0;
+            free(s);
+        }
+    }
+    return MK_FP(seg, 0);
 }
-void _RTL_FUNC farfree(void far *ptr)
+void _RTL_FUNC farfree(void far* ptr)
 {
-   SELECTOR seg = FP_SEG(ptr) ;
-   ULONG base ;
-   if (seg == _CS || seg == _DS || seg == _SS)
-      return ;
-   if (!dpmi_get_sel_base(&base,seg)) {
-      free((void *)base) ;
-      dpmi_free_selector(seg) ;
-   }
+    SELECTOR seg = FP_SEG(ptr);
+    ULONG base;
+    if (seg == _CS || seg == _DS || seg == _SS)
+        return;
+    if (!dpmi_get_sel_base(&base, seg))
+    {
+        free((void*)base);
+        dpmi_free_selector(seg);
+    }
 }

--- a/src/clibs/alloc/farmems.c
+++ b/src/clibs/alloc/farmems.c
@@ -1,26 +1,26 @@
 /* Software License Agreement
- * 
+ *
  *     Copyright(C) 1994-2018 David Lindauer, (LADSoft)
- * 
+ *
  *     This file is part of the Orange C Compiler package.
- * 
+ *
  *     The Orange C Compiler package is free software: you can redistribute it and/or modify
  *     it under the terms of the GNU General Public License as published by
  *     the Free Software Foundation, either version 3 of the License, or
- *     (at your option) any later version, with the addition of the 
+ *     (at your option) any later version, with the addition of the
  *     Orange C "Target Code" exception.
- * 
+ *
  *     The Orange C Compiler package is distributed in the hope that it will be useful,
  *     but WITHOUT ANY WARRANTY; without even the implied warranty of
  *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  *     GNU General Public License for more details.
- * 
+ *
  *     You should have received a copy of the GNU General Public License
  *     along with Orange C.  If not, see <http://www.gnu.org/licenses/>.
- * 
+ *
  *     contact information:
  *         email: TouchStone222@runbox.com <David Lindauer>
- * 
+ *
  */
 
 #include <stdio.h>
@@ -32,11 +32,5 @@
 #include "libp.h"
 #include <dpmi.h>
 
-void *_RTL_FUNC farmalloc(size_t size)
-{
-   return malloc(size) ;
-}
-void _RTL_FUNC farfree(void *ptr)
-{
-   free(ptr) ;
-}
+void* _RTL_FUNC farmalloc(size_t size) { return malloc(size); }
+void _RTL_FUNC farfree(void* ptr) { free(ptr); }

--- a/src/clibs/alloc/free.c
+++ b/src/clibs/alloc/free.c
@@ -1,26 +1,26 @@
 /* Software License Agreement
- * 
+ *
  *     Copyright(C) 1994-2018 David Lindauer, (LADSoft)
- * 
+ *
  *     This file is part of the Orange C Compiler package.
- * 
+ *
  *     The Orange C Compiler package is free software: you can redistribute it and/or modify
  *     it under the terms of the GNU General Public License as published by
  *     the Free Software Foundation, either version 3 of the License, or
- *     (at your option) any later version, with the addition of the 
+ *     (at your option) any later version, with the addition of the
  *     Orange C "Target Code" exception.
- * 
+ *
  *     The Orange C Compiler package is distributed in the hope that it will be useful,
  *     but WITHOUT ANY WARRANTY; without even the implied warranty of
  *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  *     GNU General Public License for more details.
- * 
+ *
  *     You should have received a copy of the GNU General Public License
  *     along with Orange C.  If not, see <http://www.gnu.org/licenses/>.
- * 
+ *
  *     contact information:
  *         email: TouchStone222@runbox.com <David Lindauer>
- * 
+ *
  */
 
 #include <stdio.h>
@@ -32,29 +32,29 @@
 #include <wchar.h>
 #include "libp.h"
 
-extern FREELIST *__mallocchains[MEMCHAINS];
+extern FREELIST* __mallocchains[MEMCHAINS];
 
-void _RTL_FUNC free(void *buf)
+void _RTL_FUNC free(void* buf)
 {
     FREELIST *p, **c;
     if (!buf)
         return;
     p = buf;
- 
-    p-- ;
+
+    p--;
     int n = p->size;
     if (n < 0)
     {
-        p = (char *)buf + n;
+        p = (char*)buf + n;
         p--;
     }
     if (p->size == INT_MIN)
         return;
-    if (p->next) // already freed
+    if (p->next)  // already freed
         return;
-   __ll_enter_critical() ;
-    c = &__mallocchains[(p->size>>2) % MEMCHAINS];
+    __ll_enter_critical();
+    c = &__mallocchains[(p->size >> 2) % MEMCHAINS];
     p->next = *c;
     (*c) = p;
-   __ll_exit_critical() ;
+    __ll_exit_critical();
 }

--- a/src/clibs/alloc/malloc.c
+++ b/src/clibs/alloc/malloc.c
@@ -1,26 +1,26 @@
 /* Software License Agreement
- * 
+ *
  *     Copyright(C) 1994-2018 David Lindauer, (LADSoft)
- * 
+ *
  *     This file is part of the Orange C Compiler package.
- * 
+ *
  *     The Orange C Compiler package is free software: you can redistribute it and/or modify
  *     it under the terms of the GNU General Public License as published by
  *     the Free Software Foundation, either version 3 of the License, or
- *     (at your option) any later version, with the addition of the 
+ *     (at your option) any later version, with the addition of the
  *     Orange C "Target Code" exception.
- * 
+ *
  *     The Orange C Compiler package is distributed in the hope that it will be useful,
  *     but WITHOUT ANY WARRANTY; without even the implied warranty of
  *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  *     GNU General Public License for more details.
- * 
+ *
  *     You should have received a copy of the GNU General Public License
  *     along with Orange C.  If not, see <http://www.gnu.org/licenses/>.
- * 
+ *
  *     contact information:
  *         email: TouchStone222@runbox.com <David Lindauer>
- * 
+ *
  */
 
 #include <stdio.h>
@@ -32,31 +32,32 @@
 #include <stdbool.h>
 #include "libp.h"
 
-FREELIST *__mallocchains[MEMCHAINS];
+FREELIST* __mallocchains[MEMCHAINS];
 
-BLKHEAD *_allocbloc;
-BLKHEAD *_newfree;
+BLKHEAD* _allocbloc;
+BLKHEAD* _newfree;
 
 #pragma rundown memdelete 2
 
 static void memdelete(void)
 {
-   BLKHEAD *p ;
-   __ll_enter_critical() ;
-   p = _allocbloc;
-    while (p) {
-        BLKHEAD *n = p->next;
+    BLKHEAD* p;
+    __ll_enter_critical();
+    p = _allocbloc;
+    while (p)
+    {
+        BLKHEAD* n = p->next;
         __ll_free(p);
         p = n;
     }
-   __ll_exit_critical() ;
+    __ll_exit_critical();
 }
 
 static bool init_block(size_t size)
 {
-    size_t ns = size+sizeof(BLKHEAD);
-    BLKHEAD *nb;
-    FREELIST *list ;
+    size_t ns = size + sizeof(BLKHEAD);
+    BLKHEAD* nb;
+    FREELIST* list;
     if (ns < ALLOCSIZE)
         ns = ALLOCSIZE;
     nb = __ll_malloc(ns);
@@ -64,87 +65,95 @@ static bool init_block(size_t size)
         return false;
     nb->next = _allocbloc;
     _allocbloc = nb;
-    list = nb->freemem = nb + 1 ;
-    list->size = ns - sizeof(BLKHEAD) ;
+    list = nb->freemem = nb + 1;
+    list->size = ns - sizeof(BLKHEAD);
     list->next = 0;
     _newfree = nb;
     return true;
 }
-static FREELIST *split(FREELIST *p, int size, FREELIST **slist)
+static FREELIST* split(FREELIST* p, int size, FREELIST** slist)
 {
-    FREELIST *rv;
-    rv = (FREELIST *)(((char *)p)+size);
-    rv->size = p->size - size ;
+    FREELIST* rv;
+    rv = (FREELIST*)(((char*)p) + size);
+    rv->size = p->size - size;
     rv->next = 0;
     *slist = rv;
     p->next = 0;
-    p->size = size ;
-     return ++p;
+    p->size = size;
+    return ++p;
 }
-void * _RTL_FUNC malloc(size_t size)
+void* _RTL_FUNC malloc(size_t size)
 {
-    FREELIST **slist;
-    register FREELIST *p;
-    register int siz1 ;
+    FREELIST** slist;
+    register FREELIST* p;
+    register int siz1;
     if (!size)
         return NULL;
-    size += 7;	/* must be the same as in realloc for comparison purposes */
+    size += 7; /* must be the same as in realloc for comparison purposes */
     size &= MALLOC_MASK;
 
     siz1 = size + sizeof(FREELIST);
 
-   __ll_enter_critical() ;
+    __ll_enter_critical();
     if (!__mallocchains[0])
     {
-        for (int i=0; i < MEMCHAINS; i++)
+        for (int i = 0; i < MEMCHAINS; i++)
         {
-            __mallocchains[i] = 1; // nonzero to help the 'double free' situation
+            __mallocchains[i] = 1;  // nonzero to help the 'double free' situation
         }
     }
     /* search the chain for reuse */
     slist = &__mallocchains[(siz1 >> 2) % MEMCHAINS];
-    while (*slist != 1) {
+    while (*slist != 1)
+    {
         p = *slist;
-        if (p->size == siz1) {
-             *slist = p->next;
-             p->next = NULL;
-         __ll_exit_critical() ;
-             return ++p;
+        if (p->size == siz1)
+        {
+            *slist = p->next;
+            p->next = NULL;
+            __ll_exit_critical();
+            return ++p;
         }
         slist = &p->next;
     }
     /* search the free blocks for free mem */
-    for (BLKHEAD* head = _newfree; head != NULL; head = head->next ) {
-        p = head->freemem ;
-        if (p) {
-            if (p->size == siz1) {
-                 head->freemem = 0;
-                 p->next = NULL;
-            __ll_exit_critical() ;
-                 return ++p;
+    for (BLKHEAD* head = _newfree; head != NULL; head = head->next)
+    {
+        p = head->freemem;
+        if (p)
+        {
+            if (p->size == siz1)
+            {
+                head->freemem = 0;
+                p->next = NULL;
+                __ll_exit_critical();
+                return ++p;
             }
-         else if (p->size > siz1+sizeof(FREELIST)) {
-            p = split(p,siz1,&head->freemem);
-            __ll_exit_critical() ;
-            return p ;
-         }
+            else if (p->size > siz1 + sizeof(FREELIST))
+            {
+                p = split(p, siz1, &head->freemem);
+                __ll_exit_critical();
+                return p;
+            }
         }
     }
     /* now get a new block */
-    if (!init_block(siz1)) {
-      __ll_exit_critical() ;
+    if (!init_block(siz1))
+    {
+        __ll_exit_critical();
         return NULL;
     }
     /* and split it up to get our block */
     p = _newfree->freemem;
-    if (p->size == siz1) {
-             _newfree->freemem = p->next ;
-             p->next = NULL;
-         __ll_exit_critical() ;
-             return ++p;
+    if (p->size == siz1)
+    {
+        _newfree->freemem = p->next;
+        p->next = NULL;
+        __ll_exit_critical();
+        return ++p;
     }
 
-   p = split(p,siz1,&_newfree->freemem);
-   __ll_exit_critical() ;
-   return p ;
+    p = split(p, siz1, &_newfree->freemem);
+    __ll_exit_critical();
+    return p;
 }

--- a/src/clibs/alloc/realloc.c
+++ b/src/clibs/alloc/realloc.c
@@ -36,7 +36,7 @@ void * _RTL_FUNC realloc(void *buf, size_t size)
     int oldsize, newsize = size ;
     char *ptr ;
     newsize +=7; /* must be the same as in malloc for comparison purposes */
-    newsize &= 0xfffffff8;
+    newsize &= MALLOC_MASK;
     if (buf)
         oldsize = (((FREELIST *)buf)-1)->size - sizeof(FREELIST);
     else 

--- a/src/clibs/alloc/realloc.c
+++ b/src/clibs/alloc/realloc.c
@@ -1,26 +1,26 @@
 /* Software License Agreement
- * 
+ *
  *     Copyright(C) 1994-2018 David Lindauer, (LADSoft)
- * 
+ *
  *     This file is part of the Orange C Compiler package.
- * 
+ *
  *     The Orange C Compiler package is free software: you can redistribute it and/or modify
  *     it under the terms of the GNU General Public License as published by
  *     the Free Software Foundation, either version 3 of the License, or
- *     (at your option) any later version, with the addition of the 
+ *     (at your option) any later version, with the addition of the
  *     Orange C "Target Code" exception.
- * 
+ *
  *     The Orange C Compiler package is distributed in the hope that it will be useful,
  *     but WITHOUT ANY WARRANTY; without even the implied warranty of
  *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  *     GNU General Public License for more details.
- * 
+ *
  *     You should have received a copy of the GNU General Public License
  *     along with Orange C.  If not, see <http://www.gnu.org/licenses/>.
- * 
+ *
  *     contact information:
  *         email: TouchStone222@runbox.com <David Lindauer>
- * 
+ *
  */
 
 #include <stdlib.h>
@@ -31,24 +31,24 @@
 #include <wchar.h>
 #include "libp.h"
 
-void * _RTL_FUNC realloc(void *buf, size_t size)
+void* _RTL_FUNC realloc(void* buf, size_t size)
 {
-    int oldsize, newsize = size ;
-    char *ptr ;
-    newsize +=7; /* must be the same as in malloc for comparison purposes */
+    int oldsize, newsize = size;
+    char* ptr;
+    newsize += 7; /* must be the same as in malloc for comparison purposes */
     newsize &= MALLOC_MASK;
     if (buf)
-        oldsize = (((FREELIST *)buf)-1)->size - sizeof(FREELIST);
-    else 
-        oldsize = (size_t)-1 ;
+        oldsize = (((FREELIST*)buf) - 1)->size - sizeof(FREELIST);
+    else
+        oldsize = (size_t)-1;
     if (oldsize == newsize)
         return buf;
     ptr = malloc(newsize);
-    if (ptr && buf) 
-    {							/* borland C allows buf to be zero... */
+    if (ptr && buf)
+    { /* borland C allows buf to be zero... */
         if (oldsize > size)
-            oldsize = size ;
-        memcpy(ptr,buf,oldsize);
+            oldsize = size;
+        memcpy(ptr, buf, oldsize);
         free(buf);
     }
     return ptr;

--- a/src/clibs/alloc/strdup.c
+++ b/src/clibs/alloc/strdup.c
@@ -1,26 +1,26 @@
 /* Software License Agreement
- * 
+ *
  *     Copyright(C) 1994-2018 David Lindauer, (LADSoft)
- * 
+ *
  *     This file is part of the Orange C Compiler package.
- * 
+ *
  *     The Orange C Compiler package is free software: you can redistribute it and/or modify
  *     it under the terms of the GNU General Public License as published by
  *     the Free Software Foundation, either version 3 of the License, or
- *     (at your option) any later version, with the addition of the 
+ *     (at your option) any later version, with the addition of the
  *     Orange C "Target Code" exception.
- * 
+ *
  *     The Orange C Compiler package is distributed in the hope that it will be useful,
  *     but WITHOUT ANY WARRANTY; without even the implied warranty of
  *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  *     GNU General Public License for more details.
- * 
+ *
  *     You should have received a copy of the GNU General Public License
  *     along with Orange C.  If not, see <http://www.gnu.org/licenses/>.
- * 
+ *
  *     contact information:
  *         email: TouchStone222@runbox.com <David Lindauer>
- * 
+ *
  */
 
 /*
@@ -30,15 +30,12 @@
 #include <stdlib.h>
 #include <string.h>
 
-char * _RTL_FUNC strdup(const char *string)
+char* _RTL_FUNC strdup(const char* string)
 {
-    char *rv = malloc(strlen(string)+1);
-  if (rv)
-      strcpy(rv,string);
-  return rv;
+    char* rv = malloc(strlen(string) + 1);
+    if (rv)
+        strcpy(rv, string);
+    return rv;
 }
 
-char * _RTL_FUNC _strdup(const char *string)
-{
-    return strdup(string);
-}
+char* _RTL_FUNC _strdup(const char* string) { return strdup(string); }

--- a/src/clibs/stdinc/io
+++ b/src/clibs/stdinc/io
@@ -37,7 +37,6 @@
 #include <float.h>
 #include <time.h>
 #include <locale.h>
-#include <wchar.h>
 #include <limits.h>
 #include <wchar.h>
 #include "_locale.h"
@@ -48,6 +47,7 @@
 #endif
 
 #define NUM_SIZE 100
+#define STP 1
 
 static char * getnum(char *string, LLONG_TYPE num,int radix,int lc,int unsign)
 {
@@ -720,53 +720,6 @@ doinf:
 	}
 	return(format);
 }
-/*
-	Software License Agreement (BSD License)
-	
-	Copyright (c) 1997-2008, David Lindauer, (LADSoft).
-	All rights reserved.
-	
-	Redistribution and use of this software in source and binary forms, with or without modification, are
-	permitted provided that the following conditions are met:
-	
-	* Redistributions of source code must retain the above
-	  copyright notice, this list of conditions and the
-	  following disclaimer.
-	
-	* Redistributions in binary form must reproduce the above
-	  copyright notice, this list of conditions and the
-	  following disclaimer in the documentation and/or other
-	  materials provided with the distribution.
-	
-	* Neither the name of LADSoft nor the names of its
-	  contributors may be used to endorse or promote products
-	  derived from this software without specific prior
-	  written permission of LADSoft.
-	
-	THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
-	WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
-	PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
-	ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
-	LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-	INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
-	TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
-	ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*/
-#include <stdio.h>
-#include <ctype.h>
-#include <string.h>
-#include <time.h>
-#include <wchar.h>
-#include <locale.h>
-#include "libp.h"
-#include <limits.h>
-#include <float.h>
-
-#ifdef _i386_
-#define USE_FLOAT
-#endif
-
-#define STP 1
 
 char * __fil2strd (FILE * restrict fil, int width, int * restrict ch, int * restrict chars)
 {

--- a/src/clibs/stdinc/io.h
+++ b/src/clibs/stdinc/io.h
@@ -158,8 +158,8 @@ int _RTL_FUNC _IMPORT _unlink(const char *);
 int _RTL_FUNC _IMPORT _write(int, const void *, unsigned int);
 
 #ifdef __cplusplus
-} ;
-} ;
+};
+};
 #endif
 
 #pragma pack()

--- a/src/clibs/stdinc/libp.h
+++ b/src/clibs/stdinc/libp.h
@@ -84,6 +84,7 @@ int __ll_remove(const char *__name);
 int __ll_rmdir(const char *name);
 
 /* malloc stuff */
+#define MALLOC_MASK 0xfffffff8
 void *__ll_malloc(size_t __size);
 void __ll_free(void *__blk);
 

--- a/src/clibs/threads/mtx.c
+++ b/src/clibs/threads/mtx.c
@@ -153,7 +153,6 @@ static int isAvailable(imtx *mtx)
 int     _RTL_FUNC mtx_timedlock(mtx_t *mtx, const timespec *xt)
 {
     imtx *p = (imtx *)*mtx;
-    int n = p->mode & ~mtx_recursive;
     __ll_enter_critical();
     if (p->sig == MTX_SIG && (xt == (void *)-1 || (xt != (void *)-1 && (p->mode == mtx_try || xt != NULL && p->mode == mtx_timed))))
     {


### PR DESCRIPTION
Includes one big thing I found in <io> that exists in stdinc for some reason, as well as a minor removal of a useless line in mtx.c

I want to take this PR to ask a better question: lea.c I see exists and I wonder if it should be updated at all to use a better malloc algorithm, https://github.com/rampantpixels/rpmalloc seems incredibly good for what is needed and supports Windows, although it is c11 based.

I bring this up because I looked around and found out most other C libraries use an entirely different methodology to malloc, most base theirs around some derivation of dlmalloc (which is what lea.c is based on), FreeBSD uses jemalloc (I don't recommend this because it has a lot of logging built into it, which is something I don't prefer because you can't remove it for performance reasons, although it does make it good for diagnostics), OpenBSD is the same, glibc uses ptmalloc2 with adjustments for glibc, MUSL goes off with their own thing, Microsoft calls their [HeapAlloc](https://docs.microsoft.com/en-us/windows/desktop/api/heapapi/nf-heapapi-heapalloc) function (wow, the wonders of the universe, a function in an OS designed to be used as malloc for once)), however, the issue with any of this is:

A. is it necessary? Probably not, I should still do heavy testing before I even go through any of this with the efficiacy of the current solution.
B. would it actually do good? Don't know until I do heavy testing, however it does seem that rpmalloc takes a lot more of the internal win32 systems into account when actually doing allocation fixes.