### PR TITLE
ocide: more secure check for cwa extension on open

### DIFF
--- a/src/ocide/ocide.c
+++ b/src/ocide/ocide.c
@@ -1,6 +1,6 @@
 /* Software License Agreement
  *
- *     Copyright(C) 1994-2018 David Lindauer, (LADSoft)
+ *     Copyright(C) 1994-2019 David Lindauer, (LADSoft)
  *
  *     This file is part of the Orange C Compiler package.
  *
@@ -442,9 +442,11 @@ static DWORD LoadFirstWorkArea(void* v)
         {
             int i;
             char cwd[256];
+            char *ext ==;
+            if (argc == 2) ext = strrchr(argv[1], '.') + 1;
             int munged = FALSE;
             StringToProfile("FILEDIR", (char*)getcwd(cwd, 256));
-            if (argc == 2 &&strstr(argv[1], ".cwa"))
+            if (ext && !strcasecmp(ext, "cwa"))
             {
                 LoadWorkArea(argv[1], TRUE);
             }

--- a/src/ocide/ocide.c
+++ b/src/ocide/ocide.c
@@ -446,7 +446,7 @@ static DWORD LoadFirstWorkArea(void* v)
             int munged = FALSE;
             StringToProfile("FILEDIR", (char*)getcwd(cwd, 256));
             if (argc == 2) ext = strrchr(argv[1], '.') + 1;
-            if (ext && !strcasecmp(ext, "cwa"))
+            if (ext && !stricmp(ext, "cwa"))
             {
                 LoadWorkArea(argv[1], TRUE);
             }

--- a/src/ocide/ocide.c
+++ b/src/ocide/ocide.c
@@ -442,10 +442,10 @@ static DWORD LoadFirstWorkArea(void* v)
         {
             int i;
             char cwd[256];
-            char *ext ==;
-            if (argc == 2) ext = strrchr(argv[1], '.') + 1;
+            char *ext = NULL;
             int munged = FALSE;
             StringToProfile("FILEDIR", (char*)getcwd(cwd, 256));
+            if (argc == 2) ext = strrchr(argv[1], '.') + 1;
             if (ext && !strcasecmp(ext, "cwa"))
             {
                 LoadWorkArea(argv[1], TRUE);


### PR DESCRIPTION
fixes #258 

The "problems" with the old implementation:

* "test.cwa.bak" opens as workspace
* "TEST.CWA" doesn't open as workspace

Both should work as expected with the PR (I haven't checked if there are other places which would benefit from something like this...)