### PR TITLE
CoffFile.h fixed typo in header guard

### DIFF
--- a/src/coff2ieee/CoffFile.h
+++ b/src/coff2ieee/CoffFile.h
@@ -23,7 +23,7 @@
  *
  */
 
-#ifndef COFFFILE_h
+#ifndef COFFFILE_H
 #    define COFFFILE_H
 
 #    include "CoffHeader.h"


### PR DESCRIPTION
As Both `COFFFILE_H` and `COFFFILE_h` are only used+defined here I'm quite sure LLVMs complaint 

~~~
./CoffFile.h(26,9):  warning: 'COFFFILE_h' is used as a header guard here, followed by #define of a different macro [-Wheader-guard]
#ifndef COFFFILE_h
        ^~~~~~~~~~
./CoffFile.h(27,13):  note: 'COFFFILE_H' is defined here; did you mean 'COFFFILE_h'?
#    define COFFFILE_H
            ^~~~~~~~~~
            COFFFILE_h
~~~