### PR TITLE
improve linux builds

### DIFF
--- a/src/occ/parse/ccmain.cpp
+++ b/src/occ/parse/ccmain.cpp
@@ -42,6 +42,12 @@ extern LIST* nonSysIncludeFiles;
 extern "C" {
     char* __stdcall GetModuleFileNameA(int handle, char* buf, int size);
 }
+#else
+#define HAVE_UNISTD_H /* assumption as work-around, not generally correct */
+#endif
+
+#ifdef HAVE_UNISTD_H
+#include <unistd.h>
 #endif
 
 #ifdef PARSER_ONLY

--- a/src/occ/parse86/piper.cpp
+++ b/src/occ/parse86/piper.cpp
@@ -1,6 +1,7 @@
 #ifndef GCCLINUX
 #    include <windows.h>
 #else
+#    include <stdlib.h>
 #    include <string.h>
 #endif
 #include <stdio.h>

--- a/src/occ/preproc/preproc.cpp
+++ b/src/occ/preproc/preproc.cpp
@@ -30,9 +30,8 @@
 #include <unistd.h>
 #else
 #include <io.h>
-#endif
-
 extern "C" char* getcwd(char*, int);
+#endif
 
 #ifdef PARSER_ONLY
 size_t ccReadFile(void* __ptr, size_t __size, size_t __n, FILE* __stream);


### PR DESCRIPTION
[VC](https://docs.microsoft.com/en-us/cpp/c-runtime-library/reference/getcwd-wgetcwd?view=vs-2017) defines it as:
```c
// defined in <direct.h>
char *_getcwd(
   char *buffer,
   int maxlen
);
```

[POSIX definition](https://linux.die.net/man/3/getcwd):
```c
// defined in  <unistd.h>
char *getcwd(char *buf, size_t size);
```


Note: In general it would be better to use `HAVE_UNISTD_H` instead of `GCCLINUX`.