### PR TITLE
Optimized memcpy

### DIFF
--- a/src/clibs/string/386/memcpy.nas
+++ b/src/clibs/string/386/memcpy.nas
@@ -29,6 +29,7 @@
 [global memcpy_x]
 SECTION code CLASS=CODE USE32
 
+    align 16
 _memcpy:
     push edi
     push esi
@@ -47,8 +48,7 @@ return:
     pop edi
     ret
     
-    lea esi, [esi + 0]	; Align by 16 bytes (correct when changing code or just replace this with the appropriate align directive)
-    
+    align 16    
 aligned:
     mov edx, [esi]
     lea edi, [eax + 4]
@@ -77,15 +77,7 @@ doSmall:
     mov [eax + ecx - 2], dx
     jmp return
 
-    nop
-    nop
-    nop
-    nop 
-    nop
-    nop
-    nop
-    nop	; 8 nops to align by 16 (correct when changing code or just use appropriate align directive
-
+    align 16
 
 memcpy_x:	; from MEMMOVE
     dec	edx

--- a/src/clibs/string/386/memcpy.nas
+++ b/src/clibs/string/386/memcpy.nas
@@ -30,13 +30,63 @@
 SECTION code CLASS=CODE USE32
 
 _memcpy:
-	push ebp
-	mov ebp, esp
-    push ebx
-    mov ecx,[ebp+ 16]
-    jecxz	x2
-    mov	edx,[ebp+8]
-    mov	ebx,[ebp+12]
+    push edi
+    push esi
+    mov exx, [esp + 20]	; cnt
+    mov eax, [esp + 12]	; dest
+    mov esi, [esp + 16]	; src
+    
+    cmp ecx, 4
+    jnb aligned
+    
+    test ecx, ecx
+    jne doSmall
+    
+return:
+    pop esi
+    pop edi
+    ret
+    
+    lea esi, [esi + 0]	; Align by 16 bytes (correct when changing code or just replace this with the appropriate align directive)
+    
+aligned:
+    mov edx, [esi]
+    lea edi, [eax + 4]
+    and edi, -4
+    mov [eax], edx
+    mov edx, [esi + ecx - 4]
+    mov [eax + ecx - 4], edx
+    mov edx, eax
+    sub edx, edi
+    add ecx, edx
+    sub esi, edx
+    shr ecx, 2
+    rep movsd
+    
+    pop esi
+    pop edi
+    ret
+    
+doSmall:
+    movzx edx, byte [esi]
+    test cl, 2
+    mov [eax], dl
+    jz return
+    
+    movzx edx, word [esi + ecx - 2]
+    mov [eax + ecx - 2], dx
+    jmp return
+
+    nop
+    nop
+    nop
+    nop 
+    nop
+    nop
+    nop
+    nop	; 8 nops to align by 16 (correct when changing code or just use appropriate align directive
+
+
 memcpy_x:	; from MEMMOVE
     dec	edx
 lp1:

--- a/src/clibs/string/386/memcpy.nas
+++ b/src/clibs/string/386/memcpy.nas
@@ -32,7 +32,7 @@ SECTION code CLASS=CODE USE32
 _memcpy:
     push edi
     push esi
-    mov exx, [esp + 20]	; cnt
+    mov ecx, [esp + 20]	; cnt
     mov eax, [esp + 12]	; dest
     mov esi, [esp + 16]	; src
     


### PR DESCRIPTION
Assuming you don't inline all memcpy or don't use a C implementation this should be better than the original (jecxz and loop ugh)