### PR TITLE
Fix up a lot of minor annoyances I found

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -91,10 +91,6 @@ PenaltyBreakString: 1000
 PenaltyExcessCharacter: 1000000
 PenaltyReturnTypeOnItsOwnLine: 60
 PointerAlignment: Left
-RawStringFormats: 
-  - Delimiter:       pb
-    Language:        TextProto
-    BasedOnStyle:    google
 ReflowComments:  true
 SortIncludes:    false
 SortUsingDeclarations: true

--- a/.gitignore
+++ b/.gitignore
@@ -113,3 +113,6 @@ src/.vs
 *.tst
 *.err
 *.out
+.vscode/
+src/*/Debug/
+src/*/Release

--- a/src/clibs/stdinc/float.h
+++ b/src/clibs/stdinc/float.h
@@ -137,6 +137,10 @@
 #define FLT_TRUE_MIN 0x1P-150
 #define LDBL_TRUE_MIN 0x1P-1075L
 
+// This is so that LIBCXX doesn't get to complain at all when you include <limits>
+// We don't support long doubles, but we can at least let it compile anyways
+#define __LDBL_DENORM_MIN__ LDBL_TRUE_MIN
+
 #ifdef __cplusplus
 extern "C"
 {

--- a/src/coff2ieee/CoffFile.cpp
+++ b/src/coff2ieee/CoffFile.cpp
@@ -365,7 +365,7 @@ ObjFile* CoffFile::ConvertToObject(std::string outputName, ObjFactory& factory)
                     relocCount = relocPointer[0].VirtualAddress;
                     relocPointer++;
                 }
-                unsigned offset = 0;
+                int offset = 0;
                 inputFile->clear();
                 while (offset < sections[i].SizeOfRawData)
                 {

--- a/src/coff2ieee/LibFromCoffDictionary.cpp
+++ b/src/coff2ieee/LibFromCoffDictionary.cpp
@@ -55,7 +55,6 @@ void LibDictionary::CreateDictionary(std::map<int, std::unique_ptr<Module>>& Mod
                 files++;
         }
     }
-    int dictpages2, dictpages1;
     int i = 0;
     for (auto& m : Modules)
     {

--- a/src/coff2ieee/LibFromCoffDictionary.h
+++ b/src/coff2ieee/LibFromCoffDictionary.h
@@ -32,7 +32,7 @@
 #include <memory>
 
 class ObjFile;
-class Module;
+struct Module;
 
 struct DictCompare
 {

--- a/src/coff2ieee/coff2ieee.vcxproj
+++ b/src/coff2ieee/coff2ieee.vcxproj
@@ -88,6 +88,7 @@
       <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>..\util;..\objlib;..\exefmt;..\olib</AdditionalIncludeDirectories>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
+      <ConformanceMode>true</ConformanceMode>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>

--- a/src/dlhex/IntelOutputObject.cpp
+++ b/src/dlhex/IntelOutputObject.cpp
@@ -43,7 +43,7 @@ void IntelOutputObject::putrecord(std::fstream& stream, unsigned char* data, int
 }
 void IntelOutputObject::putulba(std::fstream& stream, int address)
 {
-    int cs = 0, i;
+    int cs = 0;
     int len;
     int offset;
     int type;

--- a/src/dlhex/MotorolaOutputObject.cpp
+++ b/src/dlhex/MotorolaOutputObject.cpp
@@ -87,7 +87,7 @@ void MotorolaOutputObject::putendrec(std::fstream& stream)
 }
 void MotorolaOutputObject::putheaderrec(std::fstream& stream)
 {
-    int cs = 0, i;
+    int cs = 0;
     int len = name.size() + 5;
     cs += len;
     stream << "S0" << ObjUtil::ToHex(len, 2) << "0000";

--- a/src/dlhex/dlhex.vcxproj
+++ b/src/dlhex/dlhex.vcxproj
@@ -88,6 +88,7 @@
       <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>..\ocpp;..\util;..\objlib;..\sqlite3;..\exefmt</AdditionalIncludeDirectories>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
+      <ConformanceMode>true</ConformanceMode>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>

--- a/src/dlle/ResidentNameTable.cpp
+++ b/src/dlle/ResidentNameTable.cpp
@@ -32,9 +32,9 @@ void ResidentNameTable::Setup()
         fileName = fileName.substr(npos + 1);
     entryOffset = fileName.size() + 2;
     size = entryOffset + 1;
-    data =std::make_unique<char[]>(size);
-    data.get()[0] = fileName.size();
-    memcpy(data.get() + 1, fileName.c_str(), fileName.size() + 1);
-    data.get()[entryOffset] = 0;
+    data = std::string(' ', size);
+    data[0] = fileName.size();
+    memcpy((void*)(data.c_str() + 1), fileName.c_str(), fileName.size() + 1);
+    data[entryOffset] = 0;
 }
-void ResidentNameTable::Write(std::fstream& stream) { stream.write((char*)data.get(), size); }
+void ResidentNameTable::Write(std::fstream& stream) { stream.write(data.c_str(), size); }

--- a/src/dlle/ResidentNameTable.h
+++ b/src/dlle/ResidentNameTable.h
@@ -32,7 +32,7 @@
 class ResidentNameTable
 {
   public:
-    ResidentNameTable(const std::string& FileName) : fileName(FileName) {}
+    ResidentNameTable(const std::string& FileName) : fileName(FileName), size(0), data(""), entryOffset(0) {}
     virtual ~ResidentNameTable() { }
     unsigned GetEntrySize() { return entryOffset; }
     unsigned GetSize() { return size; }
@@ -41,7 +41,7 @@ class ResidentNameTable
 
   private:
     std::string fileName;
-    std::unique_ptr<char[]> data;
+    std::string data;
     int entryOffset;
     int size;
 };

--- a/src/dlle/dlle.vcxproj
+++ b/src/dlle/dlle.vcxproj
@@ -88,6 +88,7 @@
       <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>..\ocpp;..\util;..\objlib;..\sqlite3;..\exefmt</AdditionalIncludeDirectories>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
+      <ConformanceMode>true</ConformanceMode>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>

--- a/src/dlmz/dlmz.vcxproj
+++ b/src/dlmz/dlmz.vcxproj
@@ -88,6 +88,7 @@
       <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>..\ocpp;..\util;..\objlib;..\sqlite3;..\exefmt</AdditionalIncludeDirectories>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
+      <ConformanceMode>true</ConformanceMode>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>

--- a/src/dlpe/PEImportObject.cpp
+++ b/src/dlpe/PEImportObject.cpp
@@ -61,7 +61,7 @@ void PEImportObject::Setup(ObjInt& endVa, ObjInt& endPhys)
         ObjImportSymbol* s = (ObjImportSymbol*)(*it);
         // uppercase the module name for NT... 98 doesn't need it but can accept it
         name = s->GetDllName();
-        for (int i = 0; i < name.size(); i++)
+        for (size_t i = 0; i < name.size(); i++)
             name[i] = toupper(name[i]);
         s->SetDllName(name);
         if (externs.find((*it)->GetName()) != externs.end())
@@ -120,7 +120,7 @@ void PEImportObject::Setup(ObjInt& endVa, ObjInt& endPhys)
         if (n & 1)
             n++;
         namePos += n;
-        for (int i = 0; i < module.second->externalNames.size(); i++)
+        for (size_t i = 0; i < module.second->externalNames.size(); i++)
         {
             const std::string& str = module.second->externalNames[i];
             if (!str.empty())

--- a/src/dlpe/PEObject.cpp
+++ b/src/dlpe/PEObject.cpp
@@ -41,9 +41,9 @@ ObjFile* PEObject::file;
 void PEObject::WriteHeader(std::fstream& stream)
 {
     unsigned zero = 0;
-    for (int i = 0; i < name.size() && i < 8; i++)
+    for (size_t i = 0; i < name.size() && i < 8; i++)
         stream.write(&name[i], 1);
-    for (int i = name.size(); i < 8; i++)
+    for (size_t i = name.size(); i < 8; i++)
         stream.write((char*)&zero, 1);
     unsigned msize = ObjectAlign(objectAlign, size);
     stream.write((char*)&msize, 4);

--- a/src/dlpe/dlpe.vcxproj
+++ b/src/dlpe/dlpe.vcxproj
@@ -88,6 +88,7 @@
       <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;MICROSOFT;%(PreprocessorDefinitions); SQLITE_THREADSAFE=0</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>..\ocpp;..\util;..\objlib;..\sqlite3;..\exefmt</AdditionalIncludeDirectories>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
+      <ConformanceMode>true</ConformanceMode>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>

--- a/src/dlpm/dlpm.vcxproj
+++ b/src/dlpm/dlpm.vcxproj
@@ -88,6 +88,7 @@
       <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>..\ocpp;..\util;..\objlib;..\sqlite3;..\exefmt</AdditionalIncludeDirectories>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
+      <ConformanceMode>true</ConformanceMode>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>

--- a/src/oasm/AsmExpr.cpp
+++ b/src/oasm/AsmExpr.cpp
@@ -97,7 +97,6 @@ AsmExprNode* AsmExpr::Build(std::string& line)
     else
         line = "";
 
-    tokenizer.release();
     return rv;
 }
 AsmExprNode* AsmExpr::ConvertToBased(AsmExprNode* n, int pc)
@@ -618,7 +617,7 @@ AsmExprNode* AsmExpr::primary()
             if (token->GetKeyword() == closepa)
                 token = tokenizer->Next();
             else
-                throw new std::runtime_error("Expected ')'");
+                throw std::runtime_error("Expected ')'");
         }
     }
     else if (token->IsIdentifier())
@@ -635,7 +634,7 @@ AsmExprNode* AsmExpr::primary()
     {
         if (token->IsFloating())
         {
-            rv = new AsmExprNode(*(token->GetFloat()));
+            rv = new AsmExprNode(token->GetFloat());
         }
         else
         {
@@ -650,9 +649,9 @@ AsmExprNode* AsmExpr::primary()
     }
     else if (token->IsString())
     {
-        int num = 0;
+        size_t num = 0;
         std::wstring aa = token->GetString();
-        for (int i = 0; i < 4 && i < aa.size(); i++)
+        for (size_t i = 0; i < 4 && i < aa.size(); i++)
         {
             num += aa[i] << (i * 8);
         }
@@ -661,7 +660,7 @@ AsmExprNode* AsmExpr::primary()
     }
     else
     {
-        throw new std::runtime_error("Constant value expected");
+        throw std::runtime_error("Constant value expected");
         rv = new AsmExprNode(0);
     }
     return rv;
@@ -702,7 +701,7 @@ AsmExprNode* AsmExpr::unary()
             return primary();
         }
     }
-    throw new std::runtime_error("Syntax error in constant expression");
+    throw std::runtime_error("Syntax error in constant expression");
     return 0;
 }
 AsmExprNode* AsmExpr::multiply()

--- a/src/oasm/AsmExpr.h
+++ b/src/oasm/AsmExpr.h
@@ -159,7 +159,7 @@ class AsmExpr
   private:
     ppDefine* define;
     std::unique_ptr<Tokenizer> tokenizer;
-    const Token* token;
+    std::shared_ptr<Token> token;
     static KeywordHash hash;
     static std::string currentLabel;
     static Section* section;

--- a/src/oasm/AsmFile.h
+++ b/src/oasm/AsmFile.h
@@ -85,7 +85,7 @@ class AsmFile
     ObjFile* MakeFile(ObjFactory& factory, std::string& name);
     ObjSection* MakeSection(ObjFactory& factory, Section* sect);
     void MakeData(ObjFactory& factory, ObjSection* sect, Section* s);
-    const Token* GetToken() { return lexer.GetToken(); }
+    std::shared_ptr<Token> GetToken() { return lexer.GetToken(); }
     bool IsKeyword();
     int GetKeyword();
     unsigned GetTokenId();

--- a/src/oasm/AsmLexer.cpp
+++ b/src/oasm/AsmLexer.cpp
@@ -118,7 +118,7 @@ std::string Lexer::GetRestOfLine()
 }
 void Lexer::CheckAssign(std::string& line, PreProcessor& pp)
 {
-    int npos = line.find_first_not_of(" \t\r\n\v");
+    size_t npos = line.find_first_not_of(" \t\r\n\v");
     if (npos != std::string::npos)
     {
         if (line[npos] == '%')
@@ -178,10 +178,9 @@ void Lexer::CheckAssign(std::string& line, PreProcessor& pp)
                             {
                                 value = asmFile->GetValue();
                             }
-                            catch (std::runtime_error* e)
+                            catch (const std::runtime_error& e)
                             {
-                                Errors::Error(e->what());
-                                delete e;
+                                Errors::Error(e.what());
                             }
                             parsingDirective = false;
                             pp.Assign(name, value, caseInsensitive);

--- a/src/oasm/AsmLexer.h
+++ b/src/oasm/AsmLexer.h
@@ -101,7 +101,7 @@ class Lexer
 
     void SetAsmFile(AsmFile* th) { asmFile = th; }
     std::string GetRestOfLine();
-    const Token* GetToken() { return token; }
+    std::shared_ptr<Token> GetToken() { return token; }
     void NextToken();
     void Reset(const std::string& line)
     {
@@ -128,7 +128,7 @@ class Lexer
     bool atEof;
     bool stopAtEol;
     Tokenizer* tokenizer;
-    const Token* token;
+    std::shared_ptr<Token> token;
     bool parsingDirective;
     static KeywordHash hash;
     static const char* preData;

--- a/src/oasm/AsmToken.cpp
+++ b/src/oasm/AsmToken.cpp
@@ -137,7 +137,7 @@ long long NumericToken::GetInteger() const
     }
     return intValue;
 }
-const FPF* NumericToken::GetFloat() const
+FPF NumericToken::GetFloat()
 {
     if (!parsedAsFloat)
         switch (type)
@@ -145,13 +145,13 @@ const FPF* NumericToken::GetFloat() const
             case t_int:
             case t_longint:
             case t_longlongint:
-                const_cast<FPF&>(floatValue) = intValue;
+                floatValue = intValue;
                 break;
             default:
-                const_cast<FPF&>(floatValue) = (unsigned)intValue;
+                floatValue = (unsigned)intValue;
                 break;
         }
-    return &floatValue;
+    return floatValue;
 }
 bool NumericToken::Start(const std::string& line) { return isdigit(line[0]); }
 int NumericToken::Radix36(char c)
@@ -545,23 +545,23 @@ void ErrorToken::Parse(std::string& line)
     SetChars(line.substr(0, 1));
     line.erase(0, 1);
 }
-const Token* Tokenizer::Next()
+std::shared_ptr<Token> Tokenizer::Next()
 {
     size_t n = line.find_first_not_of("\t \v");
     line.erase(0, n);
     if (line.size() == 0)
-        currentToken = std::make_unique<EndToken>();
+        currentToken = std::make_shared<EndToken>();
     else if (NumericToken::Start(line))
-        currentToken = std::make_unique<NumericToken>(line);
+        currentToken = std::make_shared<NumericToken>(line);
     else if (CharacterToken::Start(line))
-        currentToken = std::make_unique<CharacterToken>(line);
+        currentToken = std::make_shared<CharacterToken>(line);
     else if (StringToken::Start(line))
-        currentToken = std::make_unique<StringToken>(line);
+        currentToken = std::make_shared<StringToken>(line);
     else if (IdentifierToken::Start(line))
-        currentToken = std::make_unique<IdentifierToken>(line, keywordTable, caseInsensitive);
+        currentToken = std::make_shared<IdentifierToken>(line, keywordTable, caseInsensitive);
     else if (keywordTable && KeywordToken::Start(line))
-        currentToken = std::make_unique<KeywordToken>(line, keywordTable);
+        currentToken = std::make_shared<KeywordToken>(line, keywordTable);
     else
-        currentToken = std::make_unique<ErrorToken>(line);
-    return currentToken.get();
+        currentToken = std::make_shared<ErrorToken>(line);
+    return currentToken;
 }

--- a/src/oasm/InstructionParser.cpp
+++ b/src/oasm/InstructionParser.cpp
@@ -203,7 +203,7 @@ Instruction* InstructionParser::Parse(const std::string args, int PC)
             bits.Reset();
             if (!Tokenize(PC))
             {
-                throw new std::runtime_error("Unknown token sequence");
+                throw std::runtime_error("Unknown token sequence");
             }
             eol = false;
             auto rv = DispatchOpcode(it->second);
@@ -221,7 +221,7 @@ Instruction* InstructionParser::Parse(const std::string args, int PC)
                     std::cout << std::endl;
 #endif
                     if (!eol)
-                        throw new std::runtime_error("Extra characters at end of line");
+                        throw std::runtime_error("Extra characters at end of line");
                     s = new Instruction(buf, (bits.GetBits() + 7) / 8);
                     //			std::cout << bits.GetBits() << std::endl;
                     for (auto& operand : operands)
@@ -247,22 +247,22 @@ Instruction* InstructionParser::Parse(const std::string args, int PC)
                 }
                 break;
                 case AERR_SYNTAX:
-                    throw new std::runtime_error("Syntax error while parsing instruction");
+                    throw std::runtime_error("Syntax error while parsing instruction");
                 case AERR_OPERAND:
-                    throw new std::runtime_error("Unknown operand");
+                    throw std::runtime_error("Unknown operand");
                 case AERR_BADCOMBINATIONOFOPERANDS:
-                    throw new std::runtime_error("Bad combination of operands");
+                    throw std::runtime_error("Bad combination of operands");
                 case AERR_UNKNOWNOPCODE:
-                    throw new std::runtime_error("Unrecognized opcode");
+                    throw std::runtime_error("Unrecognized opcode");
                 case AERR_INVALIDINSTRUCTIONUSE:
-                    throw new std::runtime_error("Invalid use of instruction");
+                    throw std::runtime_error("Invalid use of instruction");
                 default:
-                    throw new std::runtime_error("unknown error");
+                    throw std::runtime_error("unknown error");
             }
             return s;
         }
     }
-    throw new std::runtime_error("Unrecognized opcode");
+    throw std::runtime_error("Unrecognized opcode");
 }
 void InstructionParser::RenameRegisters(AsmExprNode* val)
 {
@@ -634,9 +634,9 @@ void InstructionParser::NextToken(int PC)
                     accum += line[i] << ((i - 1) * 8);
             }
             if (i == line.size())
-                throw new std::runtime_error("Expected end quote");
+                throw std::runtime_error("Expected end quote");
             if (i == 1)
-                throw new std::runtime_error("Quoted string is empty");
+                throw std::runtime_error("Quoted string is empty");
             line.erase(0, i + 1);
             id = TK_NUMERIC;
             val = new AsmExprNode(accum);

--- a/src/oasm/Listing.cpp
+++ b/src/oasm/Listing.cpp
@@ -88,7 +88,7 @@ void Listing::ListLine(std::fstream& out, std::string& line, ListedLine* cur, bo
                 outputLine += ss + ": ";
             }
             FixupContainer* fixups = cur->ins->GetFixups();
-            int z = 0;
+            size_t z = 0;
             bool first = true;
             int top = size;
             if (fixups->size() > z)

--- a/src/oasm/oasm.vcxproj
+++ b/src/oasm/oasm.vcxproj
@@ -88,6 +88,7 @@
       <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;L_INT=__int64;x64;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>..\ocpp;..\util;..\objlib;..\sqlite3</AdditionalIncludeDirectories>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
+      <ConformanceMode>true</ConformanceMode>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>

--- a/src/oasm/oasm.vcxproj.user
+++ b/src/oasm/oasm.vcxproj.user
@@ -1,9 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
-    <LocalDebuggerCommandArguments>breaks.nas</LocalDebuggerCommandArguments>
+    <LocalDebuggerCommandArguments>-! -oC:\OrangeC\src\clibs\object\startup\c0xls.o C:\OrangeC\src\clibs\platform\win32\pels\c0xls.nas</LocalDebuggerCommandArguments>
     <DebuggerFlavor>WindowsLocalDebugger</DebuggerFlavor>
-    <LocalDebuggerWorkingDirectory>\orangec\src\clibs\platform\dos32\debug</LocalDebuggerWorkingDirectory>
+    <LocalDebuggerWorkingDirectory>C:\OrangeC\src\clibs\platform\win32\pels</LocalDebuggerWorkingDirectory>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <LocalDebuggerCommandArguments>q.asm</LocalDebuggerCommandArguments>

--- a/src/oasm/x64stub.cpp
+++ b/src/oasm/x64stub.cpp
@@ -441,7 +441,7 @@ bool x64Parser::ParseDirective(AsmFile* fil, Section* sect)
         fil->NextToken();
         if (fil->IsNumber())
         {
-            int n = static_cast<const NumericToken*>(fil->GetToken())->GetInteger();
+            int n = std::static_pointer_cast<NumericToken>(fil->GetToken())->GetInteger();
             if (n == 16 || n == 32 || n == 64)
             {
                 sect->beValues[0] = n;

--- a/src/objlib/ObjIeee.h
+++ b/src/objlib/ObjIeee.h
@@ -1,25 +1,25 @@
 /* Software License Agreement
- * 
+ *
  *     Copyright(C) 1994-2019 David Lindauer, (LADSoft)
- * 
+ *
  *     This file is part of the Orange C Compiler package.
- * 
+ *
  *     The Orange C Compiler package is free software: you can redistribute it and/or modify
  *     it under the terms of the GNU General Public License as published by
  *     the Free Software Foundation, either version 3 of the License, or
  *     (at your option) any later version.
- * 
+ *
  *     The Orange C Compiler package is distributed in the hope that it will be useful,
  *     but WITHOUT ANY WARRANTY; without even the implied warranty of
  *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  *     GNU General Public License for more details.
- * 
+ *
  *     You should have received a copy of the GNU General Public License
  *     along with Orange C.  If not, see <http://www.gnu.org/licenses/>.
- * 
+ *
  *     contact information:
  *         email: TouchStone222@runbox.com <David Lindauer>
- * 
+ *
  */
 
 #ifndef OBJIEEE_H
@@ -223,28 +223,28 @@ class ObjIeeeBinary : public ObjIOBase
     void RenderBrowseInfo(ObjBrowseInfo* Memory);
     void RenderExpression(ObjByte* buf, ObjExpression* Expression);
     void PutSymbol(SymbolMap& map, int index, ObjSymbol* sym);
-    ObjSymbol* GetSymbol(SymbolMap& map, int index)
+    ObjSymbol* GetSymbol(SymbolMap& map, size_t index)
     {
         if (index >= map.size())
             return 0;
         return map[index];
     }
     void PutType(int index, ObjType* type);
-    ObjType* GetType(int index)
+    ObjType* GetType(size_t index)
     {
         if (index >= types.size())
             return 0;
         return types[index];
     }
     void PutSection(int index, ObjSection* sect);
-    ObjSection* GetSection(int index)
+    ObjSection* GetSection(size_t index)
     {
         if (index >= sections.size())
             return 0;
         return sections[index];
     }
     void PutFile(int index, ObjSourceFile* file);
-    ObjSourceFile* GetFile(int index)
+    ObjSourceFile* GetFile(size_t index)
     {
         if (index >= files.size())
             return 0;
@@ -399,6 +399,7 @@ class ObjIeeeAscii : public ObjIOBase
     bool ModuleEnd(const char* buffer, eParseType ParseType);
     bool ModuleAttributes(const char* buffer, eParseType ParseType);
     bool ModuleDate(const char* buffer, eParseType ParseType);
+    [[noreturn]]
     bool ThrowSyntax(const char* buffer, eParseType ParseType)
     {
         (void)buffer;
@@ -460,29 +461,29 @@ class ObjIeeeAscii : public ObjIOBase
     void RenderMemoryBinary(ObjMemoryManager* Memory);
     void RenderBrowseInfo(ObjBrowseInfo* Memory);
     void RenderExpression(ObjExpression* Expression);
-    void PutSymbol(SymbolMap& map, int index, ObjSymbol* sym);
-    ObjSymbol* GetSymbol(SymbolMap& map, int index)
+    void PutSymbol(SymbolMap& map, size_t index, ObjSymbol* sym);
+    ObjSymbol* GetSymbol(SymbolMap& map, size_t index)
     {
         if (index >= map.size())
             return 0;
         return map[index];
     }
-    void PutType(int index, ObjType* type);
-    ObjType* GetType(int index)
+    void PutType(size_t index, ObjType* type);
+    ObjType* GetType(size_t index)
     {
         if (index >= types.size())
             return 0;
         return types[index];
     }
-    void PutSection(int index, ObjSection* sect);
-    ObjSection* GetSection(int index)
+    void PutSection(size_t index, ObjSection* sect);
+    ObjSection* GetSection(size_t index)
     {
         if (index >= sections.size())
             return 0;
         return sections[index];
     }
-    void PutFile(int index, ObjSourceFile* file);
-    ObjSourceFile* GetFile(int index)
+    void PutFile(size_t index, ObjSourceFile* file);
+    ObjSourceFile* GetFile(size_t index)
     {
         if (index >= files.size())
             return 0;

--- a/src/objlib/ObjIeeeAsciiRead.cpp
+++ b/src/objlib/ObjIeeeAsciiRead.cpp
@@ -290,39 +290,39 @@ ObjFile* ObjIeeeAscii::HandleRead(eParseType ParseType)
         {
             done = Parse(inBuf, ParseType);
         }
-        catch (BadCS& e)
+        catch (const BadCS&)
         {
             ioBuffer = nullptr;
             return nullptr;
         }
-        catch (SyntaxError& e)
+        catch (const SyntaxError&)
         {
             ioBuffer = nullptr;
             return nullptr;
         }
     }
-    for (int i = 0; i < publics.size(); i++)
+    for (size_t i = 0; i < publics.size(); i++)
         if (publics[i])
             file->Add(publics[i]);
-    for (int i = 0; i < locals.size(); i++)
+    for (size_t i = 0; i < locals.size(); i++)
         if (locals[i])
             file->Add(locals[i]);
-    for (int i = 0; i < autos.size(); i++)
+    for (size_t i = 0; i < autos.size(); i++)
         if (autos[i])
             file->Add(autos[i]);
-    for (int i = 0; i < regs.size(); i++)
+    for (size_t i = 0; i < regs.size(); i++)
         if (regs[i])
             file->Add(regs[i]);
-    for (int i = 0; i < externals.size(); i++)
+    for (size_t i = 0; i < externals.size(); i++)
         if (externals[i])
             file->Add(externals[i]);
-    for (int i = 1024; i < types.size(); i++)
+    for (size_t i = 1024; i < types.size(); i++)
         if (types[i])
             file->Add(types[i]);
-    for (int i = 0; i < sections.size(); i++)
+    for (size_t i = 0; i < sections.size(); i++)
         if (sections[i])
             file->Add(sections[i]);
-    for (int i = 0; i < files.size(); i++)
+    for (size_t i = 0; i < files.size(); i++)
         if (files[i])
             file->Add(files[i]);
     publics.clear();
@@ -884,7 +884,7 @@ bool ObjIeeeAscii::Comment(const char* buffer, eParseType ParseType)
             }
             if (!GetCaseSensitiveFlag())
             {
-                for (int i = 0; i < name.size(); i++)
+                for (size_t i = 0; i < name.size(); i++)
                     name[i] = toupper(name[i]);
             }
             ObjExportSymbol* sym = factory->MakeExportSymbol(name);
@@ -1355,46 +1355,46 @@ bool ObjIeeeAscii::CheckSum(const char* buffer, eParseType ParseType)
 
     return false;
 }
-void ObjIeeeAscii::PutSymbol(SymbolMap& map, int index, ObjSymbol* sym)
+void ObjIeeeAscii::PutSymbol(SymbolMap& map, size_t index, ObjSymbol* sym)
 {
     if (map.size() <= index)
     {
-        int old = map.size();
+        size_t old = map.size();
         map.resize(index > 100 ? index * 2 : 200);
-        for (int i = old; i < map.size(); i++)
+        for (size_t i = old; i < map.size(); i++)
             map[i] = nullptr;
     }
     map[index] = sym;
 }
-void ObjIeeeAscii::PutType(int index, ObjType* type)
+void ObjIeeeAscii::PutType(size_t index, ObjType* type)
 {
     if (types.size() <= index)
     {
-        int old = types.size();
+        size_t old = types.size();
         types.resize(index > 100 ? index * 2 : 200);
-        for (int i = old; i < types.size(); i++)
+        for (size_t i = old; i < types.size(); i++)
             types[i] = nullptr;
     }
     types[index] = type;
 }
-void ObjIeeeAscii::PutSection(int index, ObjSection* sect)
+void ObjIeeeAscii::PutSection(size_t index, ObjSection* sect)
 {
     if (sections.size() <= index)
     {
-        int old = sections.size();
+        size_t old = sections.size();
         sections.resize(index > 100 ? index * 2 : 200);
-        for (int i = old; i < sections.size(); i++)
+        for (size_t i = old; i < sections.size(); i++)
             sections[i] = nullptr;
     }
     sections[index] = sect;
 }
-void ObjIeeeAscii::PutFile(int index, ObjSourceFile* file)
+void ObjIeeeAscii::PutFile(size_t index, ObjSourceFile* file)
 {
     if (files.size() <= index)
     {
-        int old = files.size();
+        size_t old = files.size();
         files.resize(index > 100 ? index * 2 : 200);
-        for (int i = old; i < files.size(); i++)
+        for (size_t i = old; i < files.size(); i++)
             files[i] = nullptr;
     }
     files[index] = file;

--- a/src/objlib/ObjIeeeAsciiWrite.cpp
+++ b/src/objlib/ObjIeeeAsciiWrite.cpp
@@ -104,7 +104,7 @@ void ObjIeeeAscii::RenderStructure(ObjType* Type)
     ObjString lastIndex;
     while (!fields.empty())
     {
-        int bottom;
+        size_t bottom;
         ObjString index;
         ObjString baseType;
         ObjField* current = fields.front();
@@ -127,7 +127,7 @@ void ObjIeeeAscii::RenderStructure(ObjType* Type)
             baseType = ObjUtil::ToHex(ObjType::eField);
             RenderString("ATT" + index + ",T" + baseType);
         }
-        for (unsigned j = 0; j < bottom; j++)
+        for (size_t j = 0; j < bottom; j++)
         {
             ObjField* currentField = fields[bottom - j - 1];
             RenderString(",T" + GetTypeIndex(currentField->GetBase()) + ",");
@@ -137,7 +137,7 @@ void ObjIeeeAscii::RenderStructure(ObjType* Type)
         RenderString(lastIndex + ".");
         endl();
         lastIndex = ",T" + index;
-        for (unsigned j = 0; j < bottom; j++)
+        for (size_t j = 0; j < bottom; j++)
             fields.pop_front();
     }
 }

--- a/src/objlib/ObjSymbol.cpp
+++ b/src/objlib/ObjSymbol.cpp
@@ -21,7 +21,7 @@
  *         email: TouchStone222@runbox.com <David Lindauer>
  * 
  */
-
+#define _CRT_SECURE_NO_WARNINGS
 #include "ObjExpression.h"
 #include "ObjSymbol.h"
 #include <cctype>
@@ -91,7 +91,7 @@ static char manglenames[MAX_MANGLE_NAME_COUNT][512];
 
 const char* unmang_intrins(char* buf, const char* name, const char* last)
 {
-    char cur[4096], *p = cur, *q;
+    char cur[4096], *p = cur;
     int i;
     *p++ = *name++;  // past the '$'
     while (*name != '@' && *name != '$' && *name)
@@ -621,7 +621,6 @@ const char* unmang1(char* buf, const char* name, const char* last, bool tof)
             strcat(buf, tn_volatile);
     }
 
-start:
     if (isdigit(*name))
     {
         const char* s = buf;
@@ -1031,7 +1030,6 @@ start:
 
 static const char* unmangcpptype(char* buf, const char* name, const char* last)
 {
-    int i;
     *buf++ = '<';
     while (*name && *name != '$' && *name != '@' && *name != '#')
     {

--- a/src/objlib/obj.vcxproj
+++ b/src/objlib/obj.vcxproj
@@ -77,6 +77,7 @@
       <PreprocessorDefinitions>WIN32;_DEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
       <AdditionalIncludeDirectories>..\util</AdditionalIncludeDirectories>
+      <ConformanceMode>true</ConformanceMode>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>

--- a/src/obrc/obrc.vcxproj
+++ b/src/obrc/obrc.vcxproj
@@ -88,6 +88,7 @@
       <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;%(PreprocessorDefinitions); SQLITE_THREADSAFE=0</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>..\ocpp;..\util;..\objlib;..\sqlite3</AdditionalIncludeDirectories>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
+      <ConformanceMode>true</ConformanceMode>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>

--- a/src/occ/middle/ialias.cpp
+++ b/src/occ/middle/ialias.cpp
@@ -124,11 +124,10 @@ static void PrintName(ALIASNAME* name, int offs)
 }
 static void PrintTemps(BITINT* modifiedBy)
 {
-    int i;
     if (modifiedBy)
     {
         oprintf(icdFile, "[");
-        for (i = 1; i < termCount; i++)
+        for (unsigned int i = 1; i < termCount; i++)
             if (isset(modifiedBy, i))
                 oprintf(icdFile, "T%d ", termMapUp[i]);
         oprintf(icdFile, "]");
@@ -337,7 +336,6 @@ static ALIASNAME* GetAliasName(ALIASNAME* name, int offset)
 {
     int str[(sizeof(ALIASNAME*) + sizeof(int)) / sizeof(int)];
     int hash;
-    ALIASNAME* result;
     struct UIVHash** uivs;
     str[0] = offset;
     *((ALIASNAME**)(str + 1)) = name;
@@ -423,9 +421,7 @@ static ALIASADDRESS* GetAddress(ALIASNAME* name, int offset)
 {
     int str[(sizeof(ALIASNAME*) + sizeof(int)) / sizeof(int)];
     int hash;
-    ALIASADDRESS *addr, **search;
-    IMODE* im;
-    LIST* li;
+    ALIASADDRESS **search;
     str[0] = offset;
     *((ALIASNAME**)(str + 1)) = name;
     hash = dhash((UBYTE*)str, sizeof(str));
@@ -459,7 +455,6 @@ static void CreateMem(IMODE* im)
         }
         else
         {
-            ALIASADDRESS* aa;
             p = LookupMem(im);
             p = LookupAliasName(p, 0);
         }
@@ -601,7 +596,6 @@ static void HandleAssn(QUAD* head)
             if (head->temps & TEMP_LEFT)
             {
                 // mem, temp
-                ALIASLIST* al;
                 ALIASNAME* an = LookupMem(head->ans);
                 ALIASADDRESS* aa;
                 an = LookupAliasName(an, 0);
@@ -651,7 +645,6 @@ static void HandleAssn(QUAD* head)
                 ALIASLIST* result = NULL;
                 ALIASNAME* an = LookupMem(head->dc.left);
                 ALIASADDRESS* aa;
-                ALIASLIST* addr;
                 bool xchanged = changed;
                 an = LookupAliasName(an, 0);
                 aa = LookupAddress(an, 0);
@@ -1134,7 +1127,6 @@ static void scanDepends(BITINT* bits, ALIASLIST* alin)
     while (al)
     {
         ALIASADDRESS* aa2 = (ALIASADDRESS*)al->address;
-        IMODE* im;
         while (aa2->merge)
             aa2 = aa2->merge;
         if (!isset(processBits, aa2->processIndex))
@@ -1412,13 +1404,12 @@ static void GatherInds(BITINT* p, int n, ALIASLIST* al)
 }
 static void ScanMem(void)
 {
-    int i, k;
     int n = (termCount + BITINTBITS - 1) / BITINTBITS;
     do
     {
         changed = false;
         ResetProcessed();
-        for (i = 0; i < DAGSIZE; i++)
+        for (int i = 0; i < DAGSIZE; i++)
         {
             ALIASADDRESS* aa = addresses[i];
             while (aa)

--- a/src/occ/middle/ialias.cpp
+++ b/src/occ/middle/ialias.cpp
@@ -445,7 +445,7 @@ static void CreateMem(IMODE* im)
             {
                 // make one in the case of global addresses that aren't used
                 // directly
-                IMODE* ap2 = (IMODE*)(IMODE *)Alloc(sizeof(IMODE));
+                IMODE* ap2 = (IMODE*)Alloc(sizeof(IMODE));
                 ap2->offset = im->offset;
                 ap2->mode = i_direct;
                 ap2->size = ISZ_ADDR;
@@ -629,7 +629,7 @@ static void HandleAssn(QUAD* head)
                 bool xchanged = changed;
                 ALIASNAME* an = LookupMem(head->dc.left);
                 ALIASADDRESS* aa = LookupAddress(an, 0);
-                ALIASLIST* al = (ALIASLIST*)(ALIASLIST *)aAlloc(sizeof(ALIASLIST));
+                ALIASLIST* al = (ALIASLIST*)aAlloc(sizeof(ALIASLIST));
                 al->address = aa;
                 tempInfo[head->ans->offset->v.sp->value.i]->pointsto = NULL;
                 AliasUnion(&tempInfo[head->ans->offset->v.sp->value.i]->pointsto, al);

--- a/src/occ/middle/iblock.cpp
+++ b/src/occ/middle/iblock.cpp
@@ -260,7 +260,7 @@ IMODE* liveout2(QUAD* q)
 QUAD* liveout(QUAD* node)
 {
     QUAD* outnode;
-    outnode = (QUAD*)(QUAD *)Alloc(sizeof(QUAD));
+    outnode = (QUAD*)Alloc(sizeof(QUAD));
     outnode->dc.opcode = node->dc.opcode;
     outnode->ans = node->ans;
     outnode->dc.v = node->dc.v;
@@ -482,7 +482,7 @@ static QUAD* add_dag(QUAD* newQuad)
     }
     else
     {
-        outnode = (QUAD*)(QUAD *)Alloc(sizeof(QUAD));
+        outnode = (QUAD*)Alloc(sizeof(QUAD));
         outnode->dc.opcode = i_assn;
         outnode->ans = newQuad->ans;
         outnode->dc.left = node->ans;
@@ -572,7 +572,7 @@ void addblock(int val)
     }
 
     /* block statement gets included */
-    q = (QUAD*)(QUAD *)Alloc(sizeof(QUAD));
+    q = (QUAD*)Alloc(sizeof(QUAD));
     q->dc.opcode = i_block;
     q->ans = q->dc.right = 0;
     q->dc.v.label = blockCount;
@@ -599,7 +599,7 @@ void gen_label(int labno)
     if (!wasgoto)
         addblock(i_label);
     wasgoto = false;
-    newQuad = (QUAD*)(QUAD *)Alloc(sizeof(QUAD));
+    newQuad = (QUAD*)Alloc(sizeof(QUAD));
     newQuad->dc.opcode = i_label;
     newQuad->dc.v.label = labno;
     add_intermed(newQuad);
@@ -630,7 +630,7 @@ QUAD* gen_icode_with_conflict(enum i_ops op, IMODE* res, IMODE* left, IMODE* rig
         default:
             break;
     }
-    newQuad = (QUAD*)(QUAD *)Alloc(sizeof(QUAD));
+    newQuad = (QUAD*)Alloc(sizeof(QUAD));
     newQuad->genConflict = conflicting;
     newQuad->dc.opcode = op;
     newQuad->dc.left = left;
@@ -663,7 +663,7 @@ void gen_iiconst(IMODE* res, LLONG_TYPE val)
 {
     QUAD* newQuad;
     IMODE* left = make_immed(ISZ_UINT, val);
-    newQuad = (QUAD*)(QUAD *)Alloc(sizeof(QUAD));
+    newQuad = (QUAD*)Alloc(sizeof(QUAD));
     newQuad->dc.opcode = i_assn;
     newQuad->ans = res;
     newQuad->dc.left = left;
@@ -679,7 +679,7 @@ void gen_ifconst(IMODE* res, FPF val)
  */
 {
     QUAD* newQuad;
-    newQuad = (QUAD*)(QUAD *)Alloc(sizeof(QUAD));
+    newQuad = (QUAD*)Alloc(sizeof(QUAD));
     newQuad->dc.opcode = i_fcon;
     newQuad->dc.v.f = val;
     newQuad->ans = res;
@@ -696,7 +696,7 @@ void gen_igoto(enum i_ops op, long label)
 {
     QUAD* newQuad;
     flush_dag();
-    newQuad = (QUAD*)(QUAD *)Alloc(sizeof(QUAD));
+    newQuad = (QUAD*)Alloc(sizeof(QUAD));
     newQuad->dc.opcode = op;
     newQuad->dc.left = newQuad->dc.right = newQuad->ans = 0;
     newQuad->dc.v.label = label;
@@ -711,7 +711,7 @@ void gen_data(int val)
 {
     QUAD* newQuad;
     flush_dag();
-    newQuad = (QUAD*)(QUAD *)Alloc(sizeof(QUAD));
+    newQuad = (QUAD*)Alloc(sizeof(QUAD));
     newQuad->dc.opcode = i_genword;
     newQuad->dc.left = newQuad->dc.right = newQuad->ans = 0;
     newQuad->dc.v.label = val;
@@ -730,7 +730,7 @@ void gen_icgoto(enum i_ops op, long label, IMODE* left, IMODE* right)
     if (right && right->mode == i_immed /*&& right->size == ISZ_NONE*/)
         right->size = left->size;
 
-    newQuad = (QUAD*)(QUAD *)Alloc(sizeof(QUAD));
+    newQuad = (QUAD*)Alloc(sizeof(QUAD));
     newQuad->dc.opcode = op;
     newQuad->dc.left = left;
     newQuad->dc.right = right;
@@ -751,7 +751,7 @@ QUAD* gen_igosub(enum i_ops op, IMODE* left)
 {
     QUAD* newQuad;
 
-    newQuad = (QUAD*)(QUAD *)Alloc(sizeof(QUAD));
+    newQuad = (QUAD*)Alloc(sizeof(QUAD));
     newQuad->dc.opcode = op;
     newQuad->dc.left = left;
     newQuad->dc.right = 0;
@@ -773,7 +773,7 @@ void gen_icode2(enum i_ops op, IMODE* res, IMODE* left, IMODE* right, int label)
  */
 {
     QUAD* newQuad;
-    newQuad = (QUAD*)(QUAD *)Alloc(sizeof(QUAD));
+    newQuad = (QUAD*)Alloc(sizeof(QUAD));
     newQuad->dc.opcode = op;
     newQuad->dc.left = left;
     newQuad->dc.right = right;
@@ -793,7 +793,7 @@ void gen_line(LINEDATA* data)
     QUAD* newQuad;
     if (data == 0)
         return;
-    newQuad = (QUAD*)(QUAD *)Alloc(sizeof(QUAD));
+    newQuad = (QUAD*)Alloc(sizeof(QUAD));
     newQuad->dc.opcode = i_line;
     newQuad->dc.left = (IMODE*)data; /* text */
     add_intermed(newQuad);
@@ -807,7 +807,7 @@ void gen_asm(STATEMENT* stmt)
  */
 {
     QUAD* newQuad;
-    newQuad = (QUAD*)(QUAD *)Alloc(sizeof(QUAD));
+    newQuad = (QUAD*)Alloc(sizeof(QUAD));
     newQuad->dc.opcode = i_passthrough;
     newQuad->dc.left = (IMODE*)stmt->select; /* actually is defined by the INASM module*/
     if (chosenAssembler->gen->adjust_codelab)
@@ -818,7 +818,7 @@ void gen_asm(STATEMENT* stmt)
 void gen_asmdata(STATEMENT* stmt)
 {
     QUAD* newQuad;
-    newQuad = (QUAD*)(QUAD *)Alloc(sizeof(QUAD));
+    newQuad = (QUAD*)Alloc(sizeof(QUAD));
     newQuad->dc.opcode = i_datapassthrough;
     newQuad->dc.left = (IMODE*)stmt->select; /* actually is defined by the INASM module*/
     flush_dag();
@@ -832,7 +832,7 @@ void gen_nodag(enum i_ops op, IMODE* res, IMODE* left, IMODE* right)
  */
 {
     QUAD* newQuad;
-    newQuad = (QUAD*)(QUAD *)Alloc(sizeof(QUAD));
+    newQuad = (QUAD*)Alloc(sizeof(QUAD));
     newQuad->dc.opcode = op;
     newQuad->dc.left = left;
     newQuad->dc.right = right;

--- a/src/occ/middle/iblock.cpp
+++ b/src/occ/middle/iblock.cpp
@@ -238,7 +238,6 @@ static void add_intermed(QUAD* newQuad)
 }
 IMODE* liveout2(QUAD* q)
 {
-    IMODE* rv;
     if (!q)
         return NULL;
     return q->ans;
@@ -935,7 +934,6 @@ void RemoveInstruction(QUAD* ins)
 }
 void InsertInstruction(QUAD* before, QUAD* ins)
 {
-    INSTRUCTIONLIST* l;
     ins->block = before->block;
     if (before->fwd && before->fwd->dc.opcode == i_skipcompare)
         if (before->fwd->dc.v.label)

--- a/src/occ/middle/iconfl.cpp
+++ b/src/occ/middle/iconfl.cpp
@@ -58,7 +58,6 @@ int findPartition(int T0)
 void insertConflict(int i, int j)
 {
     TEMP_INFO *ti, *tj;
-    int bucket;
     i = findPartition(i);
     j = findPartition(j);
     if (i == j)
@@ -90,7 +89,6 @@ void JoinConflictLists(int T0, int T1)
 }
 bool isConflicting(int T0, int T1)
 {
-    int bucket;
     T0 = findPartition(T0);
     T1 = findPartition(T1);
     if (T0 == T1)
@@ -99,10 +97,9 @@ bool isConflicting(int T0, int T1)
 }
 void CalculateConflictGraph(BRIGGS_SET* nodes, bool optimize)
 {
-    int i, j;
     BRIGGS_SET* live = briggsAllocc(tempCount);
     resetConflict();
-    for (i = 0; i < blockCount; i++)
+    for (int i = 0; i < blockCount; i++)
     {
 
         if (blockArray[i])
@@ -110,11 +107,10 @@ void CalculateConflictGraph(BRIGGS_SET* nodes, bool optimize)
             BITINT* p = blockArray[i]->liveOut;
             QUAD* tail = blockArray[i]->tail;
             QUAD* head = blockArray[i]->head;
-            int j, k;
             briggsClear(live);
-            for (j = 0; j < (tempCount + BITINTBITS - 1) / BITINTBITS; j++, p++)
+            for (int j = 0; j < (tempCount + BITINTBITS - 1) / BITINTBITS; j++, p++)
                 if (*p)
-                    for (k = 0; k < BITINTBITS; k++)
+                    for (int k = 0; k < BITINTBITS; k++)
                         if (*p & (1 << k))
                         {
                             if (!nodes || briggsTest(nodes, j * BITINTBITS + k))
@@ -130,7 +126,7 @@ void CalculateConflictGraph(BRIGGS_SET* nodes, bool optimize)
                     struct _phiblock* pb = pd->temps;
                     if (!nodes || briggsTest(nodes, pd->T0))
                     {
-                        for (j = 0; j < live->top; j++)
+                        for (int j = 0; j < live->top; j++)
                         {
                             insertConflict(live->data[j], pd->T0);
                         }
@@ -233,7 +229,7 @@ void CalculateConflictGraph(BRIGGS_SET* nodes, bool optimize)
                                         insertConflict(tnum, tail->dc.right->offset2->v.sp->value.i);
                                 }
                             }
-                            for (j = 0; j < live->top; j++)
+                            for (int j = 0; j < live->top; j++)
                             {
                                 if (live->data[j] != k)
                                     insertConflict(live->data[j], tnum);

--- a/src/occ/middle/iconst.cpp
+++ b/src/occ/middle/iconst.cpp
@@ -113,7 +113,7 @@ static void ReassignCompare(QUAD* d, int yes, bool reflow)
     }
     if (d->dc.opcode >= i_jne)
     {
-        BLOCKLIST *b, *n;
+        BLOCKLIST *b;
         if (yes)
         {
             d->dc.opcode = i_goto;
@@ -1446,7 +1446,6 @@ static bool evalBranch(QUAD* I, BLOCK* b)
         found = true;
         switch (I->dc.opcode)
         {
-            int mode;
             case i_jc:
             case i_ja:
             case i_jnc:
@@ -1725,7 +1724,6 @@ static void removeForward(BLOCK* start)
     {
         switch (tail->dc.opcode)
         {
-            BLOCKLIST** erasel;
             int con;
             case i_jc:
             case i_ja:

--- a/src/occ/middle/iexpr.cpp
+++ b/src/occ/middle/iexpr.cpp
@@ -1,25 +1,25 @@
 /* Software License Agreement
- * 
+ *
  *     Copyright(C) 1994-2019 David Lindauer, (LADSoft)
- * 
+ *
  *     This file is part of the Orange C Compiler package.
- * 
+ *
  *     The Orange C Compiler package is free software: you can redistribute it and/or modify
  *     it under the terms of the GNU General Public License as published by
  *     the Free Software Foundation, either version 3 of the License, or
  *     (at your option) any later version.
- * 
+ *
  *     The Orange C Compiler package is distributed in the hope that it will be useful,
  *     but WITHOUT ANY WARRANTY; without even the implied warranty of
  *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  *     GNU General Public License for more details.
- * 
+ *
  *     You should have received a copy of the GNU General Public License
  *     along with Orange C.  If not, see <http://www.gnu.org/licenses/>.
- * 
+ *
  *     contact information:
  *         email: TouchStone222@runbox.com <David Lindauer>
- * 
+ *
  */
 
 /*
@@ -298,7 +298,7 @@ IMODE* LookupCastTemp(IMODE* im, int size)
         }
         if (!sh)
         {
-            sh = (CASTTEMPHASH *)Alloc(sizeof(ch));
+            sh = (CASTTEMPHASH*)Alloc(sizeof(ch));
             memcpy(&sh->sf, &ch.sf, sizeof(ch.sf));
             sh->rv = tempreg(size, 0);
             sh->next = castHash[hash];
@@ -356,17 +356,17 @@ IMODE* make_imaddress(EXPRESSION* node, int size)
     {
         IncGlobalFlag();
         sp->allocate = true;
-        node1 = (EXPRESSION *)Alloc(sizeof(EXPRESSION));
+        node1 = (EXPRESSION*)Alloc(sizeof(EXPRESSION));
         *node1 = *node;
     }
-    ap2 = (IMODE*)(IMODE *)Alloc(sizeof(IMODE));
+    ap2 = (IMODE*)(IMODE*)Alloc(sizeof(IMODE));
     ap2->offset = node1;
     ap2->mode = i_immed;
     ap2->size = size;
     if (!sp->imvalue)  // the aliasing needs this regardless of whether we really use it
     {
         TYPE* tp = sp->tp;
-        sp->imvalue = (IMODE*)(IMODE *)Alloc(sizeof(IMODE));
+        sp->imvalue = (IMODE*)(IMODE*)Alloc(sizeof(IMODE));
         *(sp->imvalue) = *ap2;
         sp->imvalue->mode = i_direct;
         while (tp->array)
@@ -390,7 +390,7 @@ IMODE* make_bf(EXPRESSION* node, IMODE* ap, int size)
  *      construct a bit field reference
  */
 {
-    IMODE* ap1 = (IMODE *)Alloc(sizeof(IMODE));
+    IMODE* ap1 = (IMODE*)Alloc(sizeof(IMODE));
     SYMBOL* sp = varsp(ap->offset);
     if (node->startbit == -1)
         diag("Illegal bit field");
@@ -424,13 +424,13 @@ IMODE* make_immed(int size, LLONG_TYPE i)
     }
 
     IncGlobalFlag();
-    ap = (IMODE*)(IMODE *)Alloc(sizeof(IMODE));
+    ap = (IMODE*)(IMODE*)Alloc(sizeof(IMODE));
     ap->mode = i_immed;
     ap->offset = intNode(en_c_i, 0);
     ap->offset->v.i = i;
     ap->size = size;
 
-    a = (LIST*)(LIST *)Alloc(sizeof(LIST));
+    a = (LIST*)(LIST*)Alloc(sizeof(LIST));
     a->data = ap;
     a->next = immed_list[index];
     immed_list[index] = a;
@@ -446,7 +446,7 @@ IMODE* make_fimmed(int size, FPF f)
  */
 
 {
-    IMODE* ap = (IMODE*)(IMODE *)Alloc(sizeof(IMODE));
+    IMODE* ap = (IMODE*)(IMODE*)Alloc(sizeof(IMODE));
     ap->mode = i_immed;
     ap->offset = exprNode(
         (size == ISZ_FLOAT || size == ISZ_IFLOAT) ? en_c_f : (size == ISZ_DOUBLE || size == ISZ_IDOUBLE) ? en_c_d : en_c_ld, NULL,
@@ -464,7 +464,7 @@ IMODE* make_parmadj(long i)
  */
 {
     EXPRESSION* node = intNode(en_c_i, i);
-    IMODE* ap = (IMODE*)(IMODE *)Alloc(sizeof(IMODE));
+    IMODE* ap = (IMODE*)(IMODE*)Alloc(sizeof(IMODE));
     ap->mode = i_immed;
     ap->offset = node;
     return ap;
@@ -485,10 +485,10 @@ IMODE* make_ioffset(EXPRESSION* node)
     if (sp && sp->storage_class != sc_auto && sp->storage_class != sc_register)
     {
         IncGlobalFlag();
-        node1 = (EXPRESSION *)Alloc(sizeof(EXPRESSION));
+        node1 = (EXPRESSION*)Alloc(sizeof(EXPRESSION));
         *node1 = *(node->left);
     }
-    ap = (IMODE*)(IMODE *)Alloc(sizeof(IMODE));
+    ap = (IMODE*)(IMODE*)Alloc(sizeof(IMODE));
     ap->offset = node1;
     if (sp && sp->storage_class != sc_auto && sp->storage_class != sc_register)
         DecGlobalFlag();
@@ -522,7 +522,7 @@ IMODE* indnode(IMODE* ap1, int size)
     }
     if (ap1->bits)
     {
-        IMODE* ap2 = (IMODE *)Alloc(sizeof(IMODE));
+        IMODE* ap2 = (IMODE*)Alloc(sizeof(IMODE));
         *ap2 = *ap1;
 
         if (ap1->mode == i_immed)
@@ -541,7 +541,7 @@ IMODE* indnode(IMODE* ap1, int size)
     {
         IMODE* ap2 = tempreg(ap1->size, 0);
         gen_icode(i_assn, ap2, ap1, NULL);
-        ap1 = (IMODE *)Alloc(sizeof(IMODE));
+        ap1 = (IMODE*)Alloc(sizeof(IMODE));
         *ap1 = *ap2;
         ap1->mode = i_ind;
         ap1->ptrsize = ap1->size;
@@ -597,10 +597,10 @@ IMODE* indnode(IMODE* ap1, int size)
                 if (sp && sp->storage_class != sc_auto && sp->storage_class != sc_register)
                 {
                     IncGlobalFlag();
-                    node1 = (EXPRESSION *)Alloc(sizeof(EXPRESSION));
+                    node1 = (EXPRESSION*)Alloc(sizeof(EXPRESSION));
                     *node1 = *ap1->offset;
                 }
-                ap = (IMODE*)(IMODE *)Alloc(sizeof(IMODE));
+                ap = (IMODE*)(IMODE*)Alloc(sizeof(IMODE));
                 *ap = *ap1;
                 ap->offset = node1;
                 ap->retval = false;
@@ -609,7 +609,7 @@ IMODE* indnode(IMODE* ap1, int size)
             }
             else
             {
-                ap = (IMODE*)(IMODE *)Alloc(sizeof(IMODE));
+                ap = (IMODE*)(IMODE*)Alloc(sizeof(IMODE));
                 *ap = *ap1;
                 ap->retval = false;
             }
@@ -636,7 +636,7 @@ IMODE* indnode(IMODE* ap1, int size)
                     {
                         IncGlobalFlag();
                     }
-                    iml = (IMODELIST *)Alloc(sizeof(IMODELIST));
+                    iml = (IMODELIST*)Alloc(sizeof(IMODELIST));
                     iml->next = sp->imind;
                     sp->imind = iml;
                     iml->im = ap;
@@ -675,7 +675,7 @@ IMODE* gen_deref(EXPRESSION* node, SYMBOL* funcsp, int flags)
  *      return the addressing mode of a dereferenced node.
  */
 {
-    IMODE *ap1, *ap2, *ap3;
+    IMODE *ap1, *ap2;
     int siz1;
     SYMBOL* sp;
     int nt = node->left->type;
@@ -809,7 +809,7 @@ IMODE* gen_deref(EXPRESSION* node, SYMBOL* funcsp, int flags)
             aa2 = tempreg(aa1->size, 0);
             gen_icode(i_assn, aa2, aa1, NULL);
         }
-        aa1 = (IMODE*)(IMODE *)Alloc(sizeof(IMODE));
+        aa1 = (IMODE*)(IMODE*)Alloc(sizeof(IMODE));
         aa1->offset = node->left->right;
         aa1->mode = i_direct;
         aa1->size = aa2->size;
@@ -868,10 +868,9 @@ IMODE* gen_deref(EXPRESSION* node, SYMBOL* funcsp, int flags)
         /* other deref */
         switch (nt)
         {
-            EXPRESSION* node1;
             IMODE* ap2;
             case en_labcon:
-                ap1 = (IMODE*)(IMODE *)Alloc(sizeof(IMODE));
+                ap1 = (IMODE*)(IMODE*)Alloc(sizeof(IMODE));
                 ap1->mode = i_direct;
                 ap1->offset = node->left;
                 ap1->size = siz1;
@@ -1043,7 +1042,6 @@ IMODE* gen_binary(SYMBOL* funcsp, EXPRESSION* node, int flags, int size, enum i_
  */
 {
     IMODE *ap, *ap1, *ap2, *ap3;
-    int vol, rest, pragmas;
     (void)flags;
     ap3 = gen_expr(funcsp, node->left, flags, natural_size(node->left));
     ap1 = LookupLoadTemp(NULL, ap3);
@@ -1120,7 +1118,6 @@ IMODE* gen_udivide(SYMBOL* funcsp, EXPRESSION* node, int flags, int size, enum i
         if (ChooseMultiplier(d, N, &m, &post, &l))
         {
             IMODE *num = gen_expr(funcsp, node->left, F_VOL, size), *ap, *ap1, *ap2, *ap3, *ap4, *ap5;
-            QUAD* q;
             ap1 = LookupLoadTemp(NULL, num);
             ap = tempreg(n, 0);
             if (ap1 != num)
@@ -1223,13 +1220,12 @@ IMODE* gen_sdivide(SYMBOL* funcsp, EXPRESSION* node, int flags, int size, enum i
     if (!(chosenAssembler->arch->denyopts & DO_NOFASTDIV) && (n == ISZ_UINT || n == -ISZ_UINT) && node->right->type == en_c_i)
     {
         int d = node->right->v.i;
-        int ad = d < 0 ? -d : d, q;
+        int ad = d < 0 ? -d : d;
         ULLONG_TYPE m;
         int post, l, pre = 0;
         if (ChooseMultiplier(ad, 31, &m, &post, &l))
         {
             IMODE *num = gen_expr(funcsp, node->left, F_VOL, size), *ap, *ap1, *ap2, *ap3, *ap4, *ap5;
-            QUAD* q;
             ap1 = LookupLoadTemp(NULL, num);
             ap = tempreg(n, 0);
             if (ap1 != num)
@@ -1345,7 +1341,7 @@ IMODE* gen_pdiv(SYMBOL* funcsp, EXPRESSION* node, int flags, int size)
             ap1 = LookupLoadTemp(NULL, num);
             if (ap1 != num)
             {
-                gen_icode(i_assn, ap1, num, NULL); // DAL fixed
+                gen_icode(i_assn, ap1, num, NULL);  // DAL fixed
                 num = ap1;
             }
             while (!(d & 1))
@@ -1398,7 +1394,6 @@ IMODE* gen_hook(SYMBOL* funcsp, EXPRESSION* node, int flags, int size)
 {
     IMODE *ap1, *ap2, *ap3;
     int false_label, end_label;
-    LIST* idl;
     false_label = nextLabel++;
     end_label = nextLabel++;
     flags = flags | F_VOL;
@@ -1436,7 +1431,7 @@ IMODE* gen_moveblock(EXPRESSION* node, SYMBOL* funcsp)
  * Generate code to copy one structure to another
  */
 {
-    IMODE *ap1, *ap2, *ap3, *ap6, *ap7, *ap8;
+    IMODE *ap1, *ap2, *ap3, *ap6, *ap7;
     if (!node->size)
         return (0);
     if (chosenAssembler->msil)
@@ -1450,7 +1445,7 @@ IMODE* gen_moveblock(EXPRESSION* node, SYMBOL* funcsp)
             gen_expr(funcsp, node->left, F_STORE, ISZ_OBJECT);
             ap2 = gen_expr(funcsp, node->right, F_OBJECT, ISZ_OBJECT);
             gen_icode(i_parm, 0, ap2, 0);
-            ap1 = (IMODE*)(IMODE *)Alloc(sizeof(IMODE));
+            ap1 = (IMODE*)(IMODE*)Alloc(sizeof(IMODE));
             ap1->mode = i_immed;
             ap1->offset = node->left;
             ap1->size = ap2->size;
@@ -1525,7 +1520,7 @@ IMODE* gen_clearblock(EXPRESSION* node, SYMBOL* funcsp)
         ap7 = LookupLoadTemp(NULL, ap6);
         if (ap7 != ap6)
             gen_icode(i_assn, ap7, ap6, NULL);
-        ap8 = (IMODE*)(IMODE *)Alloc(sizeof(IMODE));
+        ap8 = (IMODE*)(IMODE*)Alloc(sizeof(IMODE));
         memcpy(ap8, ap7, sizeof(IMODE));
         ap8->mode = i_ind;
         gen_icode(i_clrblock, ap8, ap1, ap4);
@@ -1546,7 +1541,7 @@ IMODE* gen_cpinitblock(EXPRESSION* node, SYMBOL* funcsp, bool cp, int flags)
     ap7 = LookupLoadTemp(NULL, ap6);
     if (ap7 != ap6)
         gen_icode(i_assn, ap7, ap6, NULL);
-    ap8 = (IMODE*)(IMODE *)Alloc(sizeof(IMODE));
+    ap8 = (IMODE*)(IMODE*)Alloc(sizeof(IMODE));
     memcpy(ap8, ap7, sizeof(IMODE));
     ap8->mode = i_ind;
     ap3 = gen_expr(funcsp, node->left->right, F_VOL, ISZ_UINT);
@@ -1608,8 +1603,6 @@ IMODE* gen_assign(SYMBOL* funcsp, EXPRESSION* node, int flags, int size)
  */
 {
     IMODE *ap1, *ap2, *ap3, *ap4;
-    EXPRESSION *enode, *temp;
-    LIST *l2, *lp;
     (void)flags;
     (void)size;
     if (node->right->type == en_msil_array_init)
@@ -1619,7 +1612,7 @@ IMODE* gen_assign(SYMBOL* funcsp, EXPRESSION* node, int flags, int size)
         while (isarray(base))
             base = basetype(base)->btp;
         ap1 = gen_expr(funcsp, node->left, (flags & ~F_NOVALUE) | F_STORE, isstructured(base) ? ISZ_OBJECT : sizeFromType(base));
-        ap2 = (IMODE*)(IMODE *)Alloc(sizeof(IMODE));
+        ap2 = (IMODE*)(IMODE*)Alloc(sizeof(IMODE));
         ap2->mode = i_immed;
         ap2->offset = node->right;
         ap2->size = ap1->size;
@@ -1633,7 +1626,7 @@ IMODE* gen_assign(SYMBOL* funcsp, EXPRESSION* node, int flags, int size)
         gen_expr(funcsp, node->left, (flags & ~F_NOVALUE) | F_STORE, sizeFromType(base));
         ap2 = gen_expr(funcsp, node->right, (flags & ~F_NOVALUE), sizeFromType(base));
         // gen_icode(i_parm, 0, ap2, 0);
-        ap1 = (IMODE*)(IMODE *)Alloc(sizeof(IMODE));
+        ap1 = (IMODE*)(IMODE*)Alloc(sizeof(IMODE));
         ap1->mode = i_immed;
         ap1->offset = node->left;
         ap1->size = ap2->size;
@@ -1872,7 +1865,7 @@ IMODE* gen_aincdec(SYMBOL* funcsp, EXPRESSION* node, int flags, int size, enum i
         ap5 = LookupLoadTemp(ap1, ap1);
         if (ap5 != ap1)
             gen_icode(i_assn, ap5, ap1, NULL);
-        l = (LIST *)Alloc(sizeof(LIST));
+        l = (LIST*)Alloc(sizeof(LIST));
         l->data = (void*)node;
         if (!incdecList)
             incdecList = incdecListLast = l;
@@ -2026,7 +2019,7 @@ static int push_stackblock(TYPE* tp, EXPRESSION* ep, SYMBOL* funcsp, int sz, boo
  * Push a structure on the stack
  */
 {
-    IMODE *ap, *ap1, *ap2, *ap3;
+    IMODE *ap, *ap3;
     if (!sz)
         return 0;
     switch (ep->type)
@@ -2038,7 +2031,7 @@ static int push_stackblock(TYPE* tp, EXPRESSION* ep, SYMBOL* funcsp, int sz, boo
             ap3 = gen_expr(funcsp, ep, F_ADDR, ISZ_UINT);
             if (ap3->mode != i_direct && (chosenAssembler->arch->preferopts & OPT_ARGSTRUCTREF))
             {
-                ap = (IMODE *)oAlloc(sizeof(IMODE));
+                ap = (IMODE*)oAlloc(sizeof(IMODE));
                 *ap = *ap3;
                 ap3 = ap;
                 ap3->mode = i_direct;
@@ -2070,12 +2063,12 @@ static int gen_parm(INITLIST* a, SYMBOL* funcsp)
     {
         if (!objectArray_exp)
         {
-            TYPE* tp = (TYPE *)Alloc(sizeof(TYPE));
+            TYPE* tp = (TYPE*)Alloc(sizeof(TYPE));
             tp->type = bt_pointer;
             tp->size = 0;
             tp->array = tp->msil = true;
             tp->rootType = tp;
-            tp->btp = (TYPE *)Alloc(sizeof(TYPE));
+            tp->btp = (TYPE*)Alloc(sizeof(TYPE));
             tp->btp->type = bt___object;
             tp->btp->size = getSize(bt_pointer);
             tp->btp->rootType = tp->btp;
@@ -2314,19 +2307,19 @@ static int MarkFastcall(SYMBOL* sym, TYPE* functp, bool thisptr)
                     TYPE* tp = basetype(sp->tp);
                     if (thisptr ||
                         ((tp->type < bt_float || (tp->type == bt_pointer && basetype(basetype(tp)->btp)->type != bt_func) ||
-                         isref(tp)) &&
-                            sp->offset - (chosenAssembler->arch->fastcallRegCount + structret) * chosenAssembler->arch->parmwidth <
-                                chosenAssembler->arch->retblocksize))
+                          isref(tp)) &&
+                         sp->offset - (chosenAssembler->arch->fastcallRegCount + structret) * chosenAssembler->arch->parmwidth <
+                             chosenAssembler->arch->retblocksize))
                     {
                         IMODE* temp = tempreg(tail->dc.left->size, 0);
-                        QUAD* q = (QUAD*)(QUAD *)Alloc(sizeof(QUAD));
+                        QUAD* q = (QUAD*)(QUAD*)Alloc(sizeof(QUAD));
                         *q = *tail;
                         q->dc.opcode = i_assn;
                         q->ans = temp;
                         tail->dc.left = temp;
                         tail->fastcall = ++i;
                         if (tail->dc.left->size == ISZ_ULONGLONG || tail->dc.left->size == -ISZ_ULONGLONG)
-                            ++i;// long long is presently meant to be the one and only arg...
+                            ++i;  // long long is presently meant to be the one and only arg...
                         q->back = tail->back;
                         q->fwd = tail;
                         q->back->fwd = q;
@@ -2421,7 +2414,8 @@ IMODE* gen_funccall(SYMBOL* funcsp, EXPRESSION* node, int flags)
         int v = sizeFromISZ(ISZ_ADDR);
         if (v % chosenAssembler->arch->stackalign)
             v = v + chosenAssembler->arch->stackalign - v % chosenAssembler->arch->stackalign;
-        if (isfunction(f->functp) && (isstructured(basetype(f->functp)->btp) || basetype(basetype(f->functp)->btp)->type == bt_memberptr))
+        if (isfunction(f->functp) &&
+            (isstructured(basetype(f->functp)->btp) || basetype(basetype(f->functp)->btp)->type == bt_memberptr))
         {
             if (f->returnEXP)
                 n += v;
@@ -2507,7 +2501,8 @@ IMODE* gen_funccall(SYMBOL* funcsp, EXPRESSION* node, int flags)
         fastcallSize = MarkFastcall(f->sp, f->functp, !!f->thisptr);
         if (!(chosenAssembler->arch->preferopts & OPT_REVERSEPARAM))
         {
-            if (isfunction(f->functp) && (isstructured(basetype(f->functp)->btp) || basetype(basetype(f->functp)->btp)->type == bt_memberptr))
+            if (isfunction(f->functp) &&
+                (isstructured(basetype(f->functp)->btp) || basetype(basetype(f->functp)->btp)->type == bt_memberptr))
             {
                 if (f->returnEXP && !managed)
                     push_param(f->returnEXP, funcsp, false, nullptr, 0);
@@ -2538,7 +2533,7 @@ IMODE* gen_funccall(SYMBOL* funcsp, EXPRESSION* node, int flags)
         {
             if (f->sp && f->sp->attribs.inheritable.linkage2 == lk_import && (!chosenAssembler->msil))
             {
-                IMODE* ap1 = (IMODE*)(IMODE *)Alloc(sizeof(IMODE));
+                IMODE* ap1 = (IMODE*)(IMODE*)Alloc(sizeof(IMODE));
                 *ap1 = *ap;
                 ap1->retval = false;
                 ap = ap1;
@@ -2549,7 +2544,7 @@ IMODE* gen_funccall(SYMBOL* funcsp, EXPRESSION* node, int flags)
         {
             IMODE* ap1 = ap;
             gen_icode(i_assn, ap = tempreg(ISZ_ADDR, 0), ap1, 0);
-            ap1 = (IMODE*)(IMODE *)Alloc(sizeof(IMODE));
+            ap1 = (IMODE*)(IMODE*)Alloc(sizeof(IMODE));
             *ap1 = *ap;
             ap1->retval = false;
             ap = ap1;
@@ -2619,10 +2614,9 @@ IMODE* gen_funccall(SYMBOL* funcsp, EXPRESSION* node, int flags)
         if (!(flags & F_INRETURN))
         {
             IMODE* ap1;
-            int siz1;
             if (stobj)
             {
-                ap1 = (IMODE *)Alloc(sizeof(IMODE));
+                ap1 = (IMODE*)Alloc(sizeof(IMODE));
                 *ap1 = *stobj;
                 ap1->mode = i_ind;
                 ap1->size = ISZ_OBJECT;
@@ -2646,10 +2640,9 @@ IMODE* gen_funccall(SYMBOL* funcsp, EXPRESSION* node, int flags)
     else if (!(flags & F_NOVALUE) && isfunction(f->functp) && isarray(basetype(f->functp)->btp))
     {
         IMODE* ap1;
-        int siz1;
         if (stobj)
         {
-            ap1 = (IMODE *)Alloc(sizeof(IMODE));
+            ap1 = (IMODE*)Alloc(sizeof(IMODE));
             *ap1 = *stobj;
             ap1->mode = i_ind;
             ap1->size = ISZ_OBJECT;
@@ -2669,7 +2662,7 @@ IMODE* gen_funccall(SYMBOL* funcsp, EXPRESSION* node, int flags)
         /* structures handled by callee... */
         if (!isstructured(basetype(f->functp)->btp) && basetype(f->functp)->btp->type != bt_memberptr)
         {
-            IMODE *ap1, *ap2;
+            IMODE* ap1;
             int siz1 = sizeFromType(basetype(f->functp)->btp);
             ap1 = tempreg(siz1, 0);
             ap1->retval = true;
@@ -2699,10 +2692,9 @@ IMODE* gen_funccall(SYMBOL* funcsp, EXPRESSION* node, int flags)
 }
 IMODE* gen_atomic_barrier(SYMBOL* funcsp, ATOMICDATA* ad, IMODE* addr, IMODE* barrier)
 {
-    IMODE *left, *right;
+    IMODE* left;
     if (needsAtomicLockFromType(ad->tp))
     {
-        IMODE* right;
         if (barrier)
         {
             left = make_immed(ISZ_UINT, -ad->memoryOrder1->v.i);
@@ -2711,7 +2703,7 @@ IMODE* gen_atomic_barrier(SYMBOL* funcsp, ATOMICDATA* ad, IMODE* addr, IMODE* ba
         {
             left = make_immed(ISZ_ADDR, ad->memoryOrder1->v.i);
             barrier = tempreg(ISZ_ADDR, 0);
-            right = make_immed(ISZ_ADDR, ad->tp->size - ATOMIC_FLAG_SPACE);
+            IMODE* right = make_immed(ISZ_ADDR, ad->tp->size - ATOMIC_FLAG_SPACE);
             gen_icode(i_add, barrier, addr, right);
         }
         gen_icode(i_atomic_flag_fence, NULL, left, barrier);
@@ -2719,14 +2711,7 @@ IMODE* gen_atomic_barrier(SYMBOL* funcsp, ATOMICDATA* ad, IMODE* addr, IMODE* ba
     }
     else
     {
-        if (barrier)
-        {
-            left = make_immed(ISZ_UINT, -ad->memoryOrder1->v.i);
-        }
-        else
-        {
-            left = make_immed(ISZ_UINT, ad->memoryOrder1->v.i);
-        }
+        left = make_immed(ISZ_UINT, barrier ? -ad->memoryOrder1->v.i : ad->memoryOrder1->v.i);
         gen_icode(i_atomic_fence, NULL, left, NULL);
         return (IMODE*)-1;
     }
@@ -2778,7 +2763,7 @@ IMODE* gen_atomic(SYMBOL* funcsp, EXPRESSION* node, int flags, int size)
             {
                 left = gen_expr(funcsp, node->v.ad->memoryOrder1, 0, ISZ_UINT);
                 gen_icode(i_atomic_fence, NULL, left, NULL);
-                EXPRESSION *exp = anonymousVar(sc_auto, node->v.ad->tp);
+                EXPRESSION* exp = anonymousVar(sc_auto, node->v.ad->tp);
                 rv = (IMODE*)Alloc(sizeof(IMODE));
                 rv->mode = i_immed;
                 rv->size = ISZ_ADDR;
@@ -2809,7 +2794,6 @@ IMODE* gen_atomic(SYMBOL* funcsp, EXPRESSION* node, int flags, int size)
                 rv = right;
                 barrier = gen_atomic_barrier(funcsp, node->v.ad, av, 0);
                 gen_atomic_barrier(funcsp, node->v.ad, av, barrier);
-
             }
             else
             {
@@ -2832,7 +2816,7 @@ IMODE* gen_atomic(SYMBOL* funcsp, EXPRESSION* node, int flags, int size)
                 av = gen_expr(funcsp, node->v.ad->address, 0, ISZ_ADDR);
                 right = gen_expr(funcsp, node->v.ad->value, F_STORE, ISZ_ADDR);
                 barrier = gen_atomic_barrier(funcsp, node->v.ad, av, 0);
-                EXPRESSION *exp = anonymousVar(sc_auto, node->v.ad->tp);
+                EXPRESSION* exp = anonymousVar(sc_auto, node->v.ad->tp);
                 rv = (IMODE*)Alloc(sizeof(IMODE));
                 rv->mode = i_immed;
                 rv->size = ISZ_ADDR;
@@ -2845,25 +2829,25 @@ IMODE* gen_atomic(SYMBOL* funcsp, EXPRESSION* node, int flags, int size)
             {
                 switch ((int)node->v.ad->third->v.i)
                 {
-                default:
-                case asplus:
-                    op = i_add;
-                    break;
-                case asminus:
-                    op = i_sub;
-                    break;
-                case asor:
-                    op = i_or;
-                    break;
-                case asand:
-                    op = i_and;
-                    break;
-                case asxor:
-                    op = i_eor;
-                    break;
-                case assign:
-                    op = i_xchg;
-                    break;
+                    default:
+                    case asplus:
+                        op = i_add;
+                        break;
+                    case asminus:
+                        op = i_sub;
+                        break;
+                    case asor:
+                        op = i_or;
+                        break;
+                    case asand:
+                        op = i_and;
+                        break;
+                    case asxor:
+                        op = i_eor;
+                        break;
+                    case assign:
+                        op = i_xchg;
+                        break;
                 }
                 sz = sizeFromType(node->v.ad->tp);
                 av = gen_expr(funcsp, node->v.ad->address, 0, ISZ_ADDR);
@@ -2908,8 +2892,9 @@ IMODE* gen_atomic(SYMBOL* funcsp, EXPRESSION* node, int flags, int size)
                 gen_icode(i_assn, rv, make_immed(ISZ_UINT, 0), NULL);
                 int labno = nextLabel++, labno2 = nextLabel++;
                 gen_icgoto(i_cmpblock, labno, right, av);
-                QUAD *q = intermed_tail;
-                while (q->dc.opcode != i_cmpblock) q = q->back;
+                QUAD* q = intermed_tail;
+                while (q->dc.opcode != i_cmpblock)
+                    q = q->back;
                 q->ans = make_immed(ISZ_UINT, node->v.ad->tp->btp->size);
                 left = gen_expr(funcsp, node->v.ad->value, F_VOL, sz);
                 gen_icode(i_assnblock, make_immed(ISZ_UINT, node->v.ad->tp->btp->size), av, left);
@@ -2934,11 +2919,12 @@ IMODE* gen_atomic(SYMBOL* funcsp, EXPRESSION* node, int flags, int size)
                 barrier = gen_atomic_barrier(funcsp, node->v.ad, av, 0);
                 if (needsAtomicLockFromType(node->v.ad->tp))
                 {
-                    IMODE *temp = tempreg(sz, 0);
-                    IMODE *asnfrom = rv;
+                    IMODE* temp = tempreg(sz, 0);
+                    IMODE* asnfrom = rv;
                     rv = tempreg(ISZ_UINT, 0);
                     gen_icode(i_assn, temp, left, NULL);
-                    int lbno = nextLabel++, lbno2 = nextLabel++;;
+                    int lbno = nextLabel++, lbno2 = nextLabel++;
+                    ;
                     gen_icode(i_sete, rv, temp, right);
                     gen_icgoto(i_je, lbno, rv, make_immed(ISZ_UINT, 0));
                     gen_icode(i_assn, temp, asnfrom, NULL);
@@ -3038,7 +3024,6 @@ IMODE* gen_expr(SYMBOL* funcsp, EXPRESSION* node, int flags, int size)
 {
     IMODE *ap1, *ap2, *ap3;
     IMODE* rv;
-    IMODE *lbarrier, *rbarrier;
     int lab0;
     int siz1;
     int store = flags & F_STORE;
@@ -3051,8 +3036,8 @@ IMODE* gen_expr(SYMBOL* funcsp, EXPRESSION* node, int flags, int size)
     }
     while (node->type == en_not_lvalue || node->type == en_lvalue)
         node = node->left;
-//    lbarrier = doatomicFence(funcsp, node, node->left, 0);
-//    rbarrier = doatomicFence(funcsp, NULL, node->right, 0);
+    //    lbarrier = doatomicFence(funcsp, node, node->left, 0);
+    //    rbarrier = doatomicFence(funcsp, NULL, node->right, 0);
     if (flags & F_NOVALUE)
     {
         if (chosenAssembler->msil)
@@ -3238,7 +3223,7 @@ IMODE* gen_expr(SYMBOL* funcsp, EXPRESSION* node, int flags, int size)
                 while (isarray(base))
                     base = basetype(base)->btp;
                 rv = tempreg(isstructured(base) ? ISZ_OBJECT : sizeFromType(base), 0);
-                ap1 = (IMODE*)(IMODE *)Alloc(sizeof(IMODE));
+                ap1 = (IMODE*)(IMODE*)Alloc(sizeof(IMODE));
                 ap1->size = rv->size;
                 ap1->mode = i_immed;
                 ap1->offset = node;
@@ -3306,7 +3291,7 @@ IMODE* gen_expr(SYMBOL* funcsp, EXPRESSION* node, int flags, int size)
             }
             else
             {
-                ap1 = (IMODE*)(IMODE *)Alloc(sizeof(IMODE));
+                ap1 = (IMODE*)(IMODE*)Alloc(sizeof(IMODE));
                 ap1->offset = node;
                 ap1->mode = i_immed;
                 if (flags & F_OBJECT)
@@ -3325,7 +3310,7 @@ IMODE* gen_expr(SYMBOL* funcsp, EXPRESSION* node, int flags, int size)
             node->v.sp->imaddress = ap1;
             break;
         case en_labcon:
-            ap1 = (IMODE*)(IMODE *)Alloc(sizeof(IMODE));
+            ap1 = (IMODE*)(IMODE*)Alloc(sizeof(IMODE));
             ap1->offset = node;
             ap1->mode = i_immed;
             ap1->size = size;
@@ -3375,7 +3360,7 @@ IMODE* gen_expr(SYMBOL* funcsp, EXPRESSION* node, int flags, int size)
             rv = ap1;
             break;
         case en_c_string:
-            ap1 = (IMODE*)(IMODE *)Alloc(sizeof(IMODE));
+            ap1 = (IMODE*)(IMODE*)Alloc(sizeof(IMODE));
             ap1->mode = i_immed;
             ap1->size = ISZ_STRING;
             ap1->offset = node;
@@ -3393,7 +3378,7 @@ IMODE* gen_expr(SYMBOL* funcsp, EXPRESSION* node, int flags, int size)
             }
             else
             {
-                LLONG_TYPE a = (LLONG_TYPE) node->v.f;
+                LLONG_TYPE a = (LLONG_TYPE)node->v.f;
                 ap1 = make_immed(size, a);
             }
             ap1->offset->type = node->type;
@@ -3408,7 +3393,7 @@ IMODE* gen_expr(SYMBOL* funcsp, EXPRESSION* node, int flags, int size)
         case en_c_fc:
         case en_c_dc:
         case en_c_ldc:
-            ap1 = (IMODE *)Alloc(sizeof(IMODE));
+            ap1 = (IMODE*)Alloc(sizeof(IMODE));
             ap1->mode = i_immed;
             ap1->offset = node;
             switch (node->type)
@@ -3635,7 +3620,7 @@ IMODE* gen_expr(SYMBOL* funcsp, EXPRESSION* node, int flags, int size)
                     aa2 = tempreg(aa1->size, 0);
                     gen_icode(i_assn, aa2, aa1, NULL);
                 }
-                aa1 = (IMODE*)(IMODE *)Alloc(sizeof(IMODE));
+                aa1 = (IMODE*)(IMODE*)Alloc(sizeof(IMODE));
                 aa1->offset = node->right;
                 aa1->mode = i_immed;
                 aa1->size = aa2->size;
@@ -3718,8 +3703,8 @@ IMODE* gen_expr(SYMBOL* funcsp, EXPRESSION* node, int flags, int size)
         }
         DumpIncDec(funcsp);
     }
-//    doatomicFence(funcsp, NULL, node->right, rbarrier);
-//    doatomicFence(funcsp, NULL, node->left, lbarrier);
+    //    doatomicFence(funcsp, NULL, node->right, rbarrier);
+    //    doatomicFence(funcsp, NULL, node->left, lbarrier);
     return rv;
 }
 
@@ -4008,7 +3993,6 @@ void gen_compare(EXPRESSION* node, SYMBOL* funcsp, i_ops btype, int label)
  */
 {
     IMODE *ap1, *ap2, *ap3;
-    IMODE* barrier;
     int siz0, siz1, size;
     siz0 = natural_size(node->left);
     siz1 = natural_size(node->right);
@@ -4024,15 +4008,15 @@ void gen_compare(EXPRESSION* node, SYMBOL* funcsp, i_ops btype, int label)
     ap2 = LookupLoadTemp(NULL, ap3);
     if (ap2 != ap3)
     {
-//        if (node->right->isatomic)
-//        {
-//            barrier = doatomicFence(funcsp, NULL, node->right, NULL);
-//        }
+        //        if (node->right->isatomic)
+        //        {
+        //            barrier = doatomicFence(funcsp, NULL, node->right, NULL);
+        //        }
         gen_icode(i_assn, ap2, ap3, NULL);
-//        if (node->right->isatomic)
-//        {
-//            doatomicFence(funcsp, NULL, node->right, barrier);
-//        }
+        //        if (node->right->isatomic)
+        //        {
+        //            doatomicFence(funcsp, NULL, node->right, barrier);
+        //        }
     }
     if (chosenAssembler->arch->preferopts & OPT_REVERSESTORE)
         ap3 = gen_expr(funcsp, node->right, F_COMPARE, size);
@@ -4041,15 +4025,15 @@ void gen_compare(EXPRESSION* node, SYMBOL* funcsp, i_ops btype, int label)
     ap1 = LookupLoadTemp(NULL, ap3);
     if (ap1 != ap3)
     {
-//        if (node->left->isatomic)
-//        {
-//            barrier = doatomicFence(funcsp, NULL, node->left, NULL);
-//        }
+        //        if (node->left->isatomic)
+        //        {
+        //            barrier = doatomicFence(funcsp, NULL, node->left, NULL);
+        //        }
         gen_icode(i_assn, ap1, ap3, NULL);
-//        if (node->left->isatomic)
-//        {
-//            doatomicFence(funcsp, NULL, node->left, barrier);
-//        }
+        //        if (node->left->isatomic)
+        //        {
+        //            doatomicFence(funcsp, NULL, node->left, barrier);
+        //        }
     }
     if (incdecList)
     {
@@ -4077,7 +4061,7 @@ void gen_compare(EXPRESSION* node, SYMBOL* funcsp, i_ops btype, int label)
 
 /*-------------------------------------------------------------------------*/
 
-IMODE* gen_set(EXPRESSION* node, SYMBOL* funcsp,i_ops btype)
+IMODE* gen_set(EXPRESSION* node, SYMBOL* funcsp, i_ops btype)
 {
     IMODE *ap1, *ap2, *ap3;
     int siz0, siz1, size;
@@ -4123,7 +4107,6 @@ static IMODE* truerelat(EXPRESSION* node, SYMBOL* funcsp)
 {
     IMODE *ap1, *ap3;
     int lab0, lab1;
-    int siz1, siz2;
     if (node == 0)
         return 0;
     switch (node->type)

--- a/src/occ/middle/iflow.cpp
+++ b/src/occ/middle/iflow.cpp
@@ -72,7 +72,6 @@ void dump_flowgraph(void)
     {
         BLOCK* b = blockArray[i];
         BLOCKLIST* list1 = b->pred;
-        int i;
         fprintf(icdFile, "\n; %d: ", b->blocknum + 1);
         while (list1)
         {
@@ -800,7 +799,6 @@ static void DominanceFrontier(BLOCK* b, int* count)
     while (c)
     {
         BLOCKLIST* bl = c->block->dominanceFrontier;
-        int i;
         while (bl)
         {
             if (!dominatedby(bl->block, b))
@@ -901,7 +899,6 @@ static void MoveBlockTo(BLOCK* b)
 {
     BLOCK* prev = b->pred->block;
     BLOCK* succ = b->succ->block;
-    QUAD* head;
     QUAD* tail = prev->tail;
     QUAD* jmp = (QUAD *)Alloc(sizeof(QUAD));
     QUAD* insert = b->tail;
@@ -1211,8 +1208,6 @@ void doms_only(bool always)
 /* main routine for creating flowgraph and dominator info */
 void flows_and_doms(void)
 {
-    BLOCKLIST* bl;
-    int i;
     if (exitBlock == 0)
     {
         exitBlock = blockCount - 1;

--- a/src/occ/middle/ilazy.cpp
+++ b/src/occ/middle/ilazy.cpp
@@ -1,25 +1,25 @@
 /* Software License Agreement
- * 
+ *
  *     Copyright(C) 1994-2019 David Lindauer, (LADSoft)
- * 
+ *
  *     This file is part of the Orange C Compiler package.
- * 
+ *
  *     The Orange C Compiler package is free software: you can redistribute it and/or modify
  *     it under the terms of the GNU General Public License as published by
  *     the Free Software Foundation, either version 3 of the License, or
  *     (at your option) any later version.
- * 
+ *
  *     The Orange C Compiler package is distributed in the hope that it will be useful,
  *     but WITHOUT ANY WARRANTY; without even the implied warranty of
  *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  *     GNU General Public License for more details.
- * 
+ *
  *     You should have received a copy of the GNU General Public License
  *     along with Orange C.  If not, see <http://www.gnu.org/licenses/>.
- * 
+ *
  *     contact information:
  *         email: TouchStone222@runbox.com <David Lindauer>
- * 
+ *
  */
 
 #include <stdio.h>
@@ -121,7 +121,6 @@ static void complementmap(BITINT* dest)
 }
 static void setmap(BITINT* dest, bool val)
 {
-    int i;
     int v = val ? 0xff : 0;
     int n = (termCount + BITINTBITS - 1) / BITINTBITS * sizeof(BITINT);
     memset(dest, v, n);
@@ -231,8 +230,6 @@ void SetunMoveableTerms(void)
 }
 static void CalculateUses(void)
 {
-    int i, j;
-    BLOCK* b;
     QUAD *head, *tail;
     setmap(tempBytes, true);
     tail = intermed_tail;
@@ -286,7 +283,6 @@ static void CalculateUses(void)
 static void CalculateTransparent(void)
 {
     int n = (termCount + BITINTBITS - 1) / BITINTBITS;
-    int i, j, k;
     QUAD *head, *tail;
     tail = intermed_tail;
     while (!tail->OCP)
@@ -312,7 +308,7 @@ static void CalculateTransparent(void)
                 next = next->fwd;
             }
             complementmap(tempBytes3);
-            for (i = 0; i < termCount; i++)
+            for (int i = 0; i < termCount; i++)
                 if (!isset(tempBytes3, i) && tempInfo[termMapUp[i]]->terms)
                 {
                     andmap(tail->transparent, tempInfo[termMapUp[i]]->terms);
@@ -323,7 +319,7 @@ static void CalculateTransparent(void)
             setmap(tempBytes, false);
             AliasStruct(tempBytes, tail->ans, tail->dc.left, tail->dc.right);
             complementmap(tempBytes);
-            for (i = 0; i < termCount; i++)
+            for (int i = 0; i < termCount; i++)
             {
                 if (!isset(tempBytes, i))
                 {
@@ -372,7 +368,7 @@ static void CalculateTransparent(void)
             {
                 setmap(tempBytes, false);
                 AliasUses(tempBytes, tail->ans, true);
-                for (i = 0; i < termCount; i++)
+                for (int i = 0; i < termCount; i++)
                 {
                     if (isset(tempBytes, i))
                     {
@@ -826,7 +822,7 @@ static void HandleOCP(QUAD* after, int tn)
     {
         QUAD* p = (QUAD*)(tempInfo[tn]->idefines->data);
         QUAD* tail = after;
-        QUAD* ins = (QUAD *)Alloc(sizeof(QUAD));
+        QUAD* ins = (QUAD*)Alloc(sizeof(QUAD));
         QUAD* bans;
         bool a = false, l = false;
         if (after->dc.opcode != i_block && after->dc.opcode != i_label)
@@ -874,7 +870,7 @@ static void HandleOCP(QUAD* after, int tn)
         ins->block = after->block;
         if (after == after->block->tail)
             after->block->tail = ins;
-        bans = (QUAD *)Alloc(sizeof(QUAD));
+        bans = (QUAD*)Alloc(sizeof(QUAD));
         bans->ans = tempInfo[tn]->copy;
         bans->dc.left = ins->ans;
         bans->dc.opcode = i_assn;
@@ -906,8 +902,8 @@ static IMODE* GetROVar(IMODE* oldvar, IMODE* newvar, bool mov)
         }
         if (!iml)
         {
-            IMODELIST* iml2 = (IMODELIST *)Alloc(sizeof(IMODELIST));
-            im = (IMODE *)Alloc(sizeof(IMODE));
+            IMODELIST* iml2 = (IMODELIST*)Alloc(sizeof(IMODELIST));
+            im = (IMODE*)Alloc(sizeof(IMODE));
             *im = *newvar;
             im->mode = i_ind;
             im->size = oldvar->size;
@@ -977,15 +973,13 @@ static void HandleRO(QUAD* after, int tn)
 }
 static void MoveExpressions(void)
 {
-    int i, j;
-    for (i = 0; i < termCount; i++)
+    for (int i = 0; i < termCount; i++)
     {
         if (isset(ocpTerms, i))
         {
-            int j;
             int size = tempInfo[termMapUp[i]]->enode->v.sp->imvalue->size;
             tempInfo[termMapUp[i]]->copy = InitTempOpt(size, size);
-            for (j = 0; j < blocks; j++)
+            for (int j = 0; j < blocks; j++)
             {
 
                 QUAD* head = forwardOrder[j]->head;
@@ -1003,12 +997,11 @@ static void MoveExpressions(void)
             }
         }
     }
-    for (i = 0; i < termCount; i++)
+    for (int i = 0; i < termCount; i++)
     {
         if (isset(ocpTerms, i))
         {
-            int j;
-            for (j = 0; j < blocks; j++)
+            for (int j = 0; j < blocks; j++)
             {
 
                 QUAD* head = forwardOrder[j]->head;
@@ -1028,15 +1021,14 @@ static void MoveExpressions(void)
 void RearrangePrecolors(void)
 {
     QUAD* head = intermed_head;
-    int i;
-    for (i = 0; i < tempCount; i++)
+    for (int i = 0; i < tempCount; i++)
         tempInfo[i]->temp = -1;
     while (head)
     {
         if ((head->precolored & TEMP_ANS) && !head->ans->retval)
         {
-            QUAD* newIns = (QUAD *)Alloc(sizeof(QUAD));
-            i = head->ans->offset->v.sp->value.i;
+            QUAD* newIns = (QUAD*)Alloc(sizeof(QUAD));
+            long long i = head->ans->offset->v.sp->value.i;
             if (tempInfo[i]->temp < 0)
             {
                 IMODE* newImode = InitTempOpt(head->ans->size, head->ans->size);
@@ -1054,8 +1046,8 @@ void RearrangePrecolors(void)
         }
         if ((head->precolored & TEMP_LEFT) && !head->dc.left->retval)
         {
-            QUAD* newIns = (QUAD *)Alloc(sizeof(QUAD));
-            i = head->dc.left->offset->v.sp->value.i;
+            QUAD* newIns = (QUAD*)Alloc(sizeof(QUAD));
+            long long i = head->dc.left->offset->v.sp->value.i;
             if (tempInfo[i]->temp < 0)
             {
                 IMODE* newImode = InitTempOpt(head->dc.left->size, head->dc.left->size);
@@ -1073,8 +1065,8 @@ void RearrangePrecolors(void)
         }
         if ((head->precolored & TEMP_RIGHT) && !head->dc.right->retval)
         {
-            QUAD* newIns = (QUAD *)Alloc(sizeof(QUAD));
-            i = head->dc.right->offset->v.sp->value.i;
+            QUAD* newIns = (QUAD*)Alloc(sizeof(QUAD));
+            long long i = head->dc.right->offset->v.sp->value.i;
             if (tempInfo[i]->temp < 0)
             {
                 IMODE* newImode = InitTempOpt(head->dc.right->size, head->dc.right->size);
@@ -1096,13 +1088,12 @@ void RearrangePrecolors(void)
 }
 static void PadBlocks(void)
 {
-    int i;
-    for (i = 0; i < blockCount; i++)
+    for (int i = 0; i < blockCount; i++)
     {
         BLOCK* b = blockArray[i];
         if (b && b->head == b->tail)
         {
-            QUAD* ins = (QUAD *)Alloc(sizeof(QUAD));
+            QUAD* ins = (QUAD*)Alloc(sizeof(QUAD));
             ins->dc.opcode = i_blockend;
             InsertInstruction(b->head, ins);
         }
@@ -1111,14 +1102,13 @@ static void PadBlocks(void)
 static int fgc(enum e_fgtype type, BLOCK* parent, BLOCK* b) { return true; }
 void SetGlobalTerms(void)
 {
-    int i, j;
     termCount = 0;
-    for (i = 0; i < tempCount; i++)
+    for (int i = 0; i < tempCount; i++)
         if (tempInfo[i]->inUse)
             termCount++;
-    termMap = (unsigned short *) Alloc(sizeof(unsigned short) * tempCount);
-    termMapUp = (unsigned short *)Alloc(sizeof(unsigned short) * termCount);
-    for (i = 0, j = 0; i < tempCount; i++)
+    termMap = (unsigned short*)Alloc(sizeof(unsigned short) * tempCount);
+    termMapUp = (unsigned short*)Alloc(sizeof(unsigned short) * termCount);
+    for (int i = 0, j = 0; i < tempCount; i++)
         if (tempInfo[i]->inUse)
         {
             termMap[i] = j;
@@ -1128,15 +1118,14 @@ void SetGlobalTerms(void)
 }
 void GlobalOptimization(void)
 {
-    int i;
     PadBlocks();
     forwardOrder = (BLOCK**)oAlloc(sizeof(BLOCK*) * blockCount);
     blocks = 0;
-    for (i = 0; i < blockCount; i++)
+    for (int i = 0; i < blockCount; i++)
         if (blockArray[i])
             blockArray[i]->visiteddfst = false;
     forwardOrder[blocks++] = blockArray[0];
-    for (i = 0; i < blocks; i++)
+    for (int i = 0; i < blocks; i++)
     {
         BLOCK* b = forwardOrder[i];
         BLOCKLIST* bl = b->succ;
@@ -1152,11 +1141,11 @@ void GlobalOptimization(void)
     }
     reverseOrder = (BLOCK**)oAlloc(sizeof(BLOCK*) * blockCount);
     blocks = 0;
-    for (i = 0; i < blockCount; i++)
+    for (int i = 0; i < blockCount; i++)
         if (blockArray[i])
             blockArray[i]->visiteddfst = false;
     reverseOrder[blocks++] = blockArray[exitBlock];
-    for (i = 0; i < blocks; i++)
+    for (int i = 0; i < blocks; i++)
     {
         BLOCK* b = reverseOrder[i];
         BLOCKLIST* bl = b->pred;

--- a/src/occ/middle/ilive.cpp
+++ b/src/occ/middle/ilive.cpp
@@ -96,7 +96,6 @@ static void liveSetup(void)
         if (blk && blk->head)
         {
             QUAD* tail = blk->tail;
-            int j;
             briggsClear(exposed);
             do
             {
@@ -180,7 +179,7 @@ static void liveSetup(void)
     }
     for (i = 0; i < globalVars->top; i++)
     {
-        int t = globalVars->data[i], j;
+        int t = globalVars->data[i];
         tempInfo[t]->liveAcrossBlock = true;
     }
 }
@@ -511,16 +510,14 @@ void removeDead(BLOCK* b)
 {
     static BRIGGS_SET* live;
     BITINT* p;
-    int j, k;
     QUAD* tail;
     BLOCKLIST* bl;
     bool done = false;
     if (b == blockArray[0])
     {
-        int i;
         liveVariables();
         live = briggsAlloc(tempCount);
-        for (i = 0; i < blockCount; i++)
+        for (int i = 0; i < blockCount; i++)
             if (blockArray[i])
             {
                 QUAD* tail = blockArray[i]->head;
@@ -535,9 +532,9 @@ void removeDead(BLOCK* b)
     b->visiteddfst = true;
     briggsClear(live);
     p = b->liveOut;
-    for (j = 0; j < (tempCount + BITINTBITS - 1) / BITINTBITS; j++, p++)
+    for (int j = 0; j < (tempCount + BITINTBITS - 1) / BITINTBITS; j++, p++)
         if (*p)
-            for (k = 0; k < BITINTBITS; k++)
+            for (int k = 0; k < BITINTBITS; k++)
                 if (*p & (1 << k))
                 {
                     briggsSet(live, j * BITINTBITS + k);
@@ -559,7 +556,6 @@ void removeDead(BLOCK* b)
     {
         QUAD* head = intermed_head;
         bool changed = false;
-        int i;
         /*
         for (i=0; i < blockCount; i++)
         {
@@ -568,7 +564,7 @@ void removeDead(BLOCK* b)
                     removeDead(blockArray[i]);
         }
         */
-        for (i = 0; i < blockCount; i++)
+        for (int i = 0; i < blockCount; i++)
         {
             BLOCK* b1 = blockArray[i];
             if (b1)
@@ -607,14 +603,13 @@ void removeDead(BLOCK* b)
 }
 void liveVariables(void)
 {
-    int i;
     sFree();
     hasPhi = false;
     globalVars = briggsAllocs(tempCount);
     worklist = briggsAllocs(blockCount);
     livelist = briggsAllocs(blockCount);
     visited = briggsAllocs(blockCount);
-    for (i = 0; i < blockCount; i++)
+    for (int i = 0; i < blockCount; i++)
     {
         if (blockArray[i])
         {
@@ -624,7 +619,7 @@ void liveVariables(void)
             blockArray[i]->liveOut = sallocbit(tempCount);
         }
     }
-    for (i = 0; i < tempCount; i++)
+    for (int i = 0; i < tempCount; i++)
     {
         tempInfo[i]->liveAcrossBlock = false;
     }

--- a/src/occ/middle/ilocal.cpp
+++ b/src/occ/middle/ilocal.cpp
@@ -280,7 +280,6 @@ static void renameToTemps(SYMBOL* funcsp)
 static int AllocTempOpt(int size1)
 {
     int t;
-    int i;
     IMODE* rv;
     while (nextTemp < tempCount)
     {

--- a/src/occ/middle/ilocal.cpp
+++ b/src/occ/middle/ilocal.cpp
@@ -183,13 +183,13 @@ static void renameOneSym(SYMBOL* sp, int structret)
                 }
                 else
                 {
-                    parmName = (IMODE*)(IMODE *)Alloc(sizeof(IMODE));
+                    parmName = (IMODE*)Alloc(sizeof(IMODE));
                     *parmName = *sp->imvalue;
                 }
             }
             else
             {
-                parmName = (IMODE*)(IMODE *)Alloc(sizeof(IMODE));
+                parmName = (IMODE*)Alloc(sizeof(IMODE));
                 *parmName = *sp->imvalue;
             }
         }

--- a/src/occ/middle/iloop.cpp
+++ b/src/occ/middle/iloop.cpp
@@ -216,7 +216,7 @@ static LOOP* LoopAncestor(BLOCK* b)
 static void FindBody(BLOCKLIST* gen, BLOCK* head, enum e_lptype type)
 {
     LIST *queue = NULL, **qx;
-    LOOP *lp, **lpp;
+    LOOP *lp;
     int i;
     if (!gen)
         return;
@@ -656,7 +656,6 @@ static void PruneInductionCandidate(int tnum, LOOP* l)
  */
 static void CalculateInductionCandidates(LOOP* l)
 {
-    LIST *blocks, *p;
     int i;
     briggsClear(candidates);
     inductionCandidateStackTop = 0;

--- a/src/occ/middle/iout.cpp
+++ b/src/occ/middle/iout.cpp
@@ -1,25 +1,25 @@
 /* Software License Agreement
- * 
+ *
  *     Copyright(C) 1994-2019 David Lindauer, (LADSoft)
- * 
+ *
  *     This file is part of the Orange C Compiler package.
- * 
+ *
  *     The Orange C Compiler package is free software: you can redistribute it and/or modify
  *     it under the terms of the GNU General Public License as published by
  *     the Free Software Foundation, either version 3 of the License, or
  *     (at your option) any later version.
- * 
+ *
  *     The Orange C Compiler package is distributed in the hope that it will be useful,
  *     but WITHOUT ANY WARRANTY; without even the implied warranty of
  *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  *     GNU General Public License for more details.
- * 
+ *
  *     You should have received a copy of the GNU General Public License
  *     along with Orange C.  If not, see <http://www.gnu.org/licenses/>.
- * 
+ *
  *     contact information:
  *         email: TouchStone222@runbox.com <David Lindauer>
- * 
+ *
  */
 
 /*
@@ -566,7 +566,7 @@ static void iop_clrblock(QUAD* q)
     putamode(q, q->dc.right);
     oprintf(icdFile, ")");
 }
-static void iop_cmpblock(QUAD *q)
+static void iop_cmpblock(QUAD* q)
 {
     if (chosenAssembler->gen->asm_cmpblock)
         chosenAssembler->gen->asm_cmpblock(q);
@@ -880,14 +880,12 @@ static void iop_blockend(QUAD* q)
     oprintf(icdFile, "\tBLOCK END");
     if (q->dc.v.data)
     {
-        int i, j;
-        BITINT* p;
         oprintf(icdFile, "\n;\tLive: ");
-        p = (BITINT *)q->dc.v.data;
+        BITINT* p = (BITINT*)q->dc.v.data;
 
-        for (i = 0; i < (tempCount + BITINTBITS - 1) / BITINTBITS; i++, p++)
+        for (int i = 0; i < (tempCount + BITINTBITS - 1) / BITINTBITS; i++, p++)
             if (*p)
-                for (j = 0; j < BITINTBITS; j++)
+                for (int j = 0; j < BITINTBITS; j++)
                     if ((*p) & (1 << j))
                         oprintf(icdFile, "TEMP%d, ", i * BITINTBITS + j);
     }
@@ -1143,7 +1141,7 @@ static void iop_cmpswp(QUAD* q)
     oputc(',', icdFile);
     putamode(q, q->dc.right);
 }
-static void iop_xchg(QUAD *q)
+static void iop_xchg(QUAD* q)
 {
     if (chosenAssembler->gen->asm_atomic)
         chosenAssembler->gen->asm_atomic(q);
@@ -1268,14 +1266,13 @@ static void (*oplst[])(QUAD* q) = {
 /*-------------------------------------------------------------------------*/
 void beDecorateSymName(char* buf, SYMBOL* sp)
 {
-    const char* q;
     if (sp->attribs.uninheritable.alias)
     {
         strcpy(buf, sp->attribs.uninheritable.alias);
     }
     else
     {
-        q = lookupAlias(sp->name);
+        const char* q = lookupAlias(sp->name);
         if (q)
             strcpy(buf, q);
         else
@@ -1360,13 +1357,11 @@ void putconst(EXPRESSION* offset, int color)
         case en_c_string:
             if (offset->string)
             {
-                int i;
                 oputc('"', icdFile);
-                for (i = 0; i < offset->string->size; i++)
+                for (int i = 0; i < offset->string->size; i++)
                 {
                     SLCHAR* s = offset->string->pointers[i];
-                    int j;
-                    for (j = 0; j < s->count; j++)
+                    for (int j = 0; j < s->count; j++)
                         oputc(s->str[j], icdFile);
                 }
                 oputc('"', icdFile);
@@ -1600,7 +1595,6 @@ void put_code(QUAD* q)
  *      output a generic instruction.
  */
 {
-    int i;
     if (q->block && q->block->head == q)
     {
         oprintf(icdFile, "block %d\n", q->block->blocknum);
@@ -2345,7 +2339,7 @@ void gen_labdifref(int n1, int n2)
     if (chosenAssembler->gen->gen_labdifref)
         chosenAssembler->gen->gen_labdifref(n1, n2);
     if (!icdFile)
-        return;
+        return;  // Is this intentional?
     {
         if (gentype == longgen && outcol < 58)
         {
@@ -2703,7 +2697,7 @@ int put_exfunc(SYMBOL* sp, int notyet)
     if (chosenAssembler->gen->extern_define)
         chosenAssembler->gen->extern_define(sp, sp->tp->type == bt_func || sp->tp->type == bt_ifunc);
     if (sp->attribs.inheritable.linkage2 == lk_import && chosenAssembler->gen->import_define)
-        chosenAssembler->gen->import_define(sp, sp->importfile ? sp->importfile : (char *)"");
+        chosenAssembler->gen->import_define(sp, sp->importfile ? sp->importfile : (char*)"");
     DecGlobalFlag();
     if (!icdFile)
         return notyet;
@@ -2739,8 +2733,6 @@ void putexterns(void)
  * Output the fixup tables and the global/external list
  */
 {
-    SYMBOL* sp;
-    int i;
     {
         int notyet = true;
         LIST* externList = externals;
@@ -2748,20 +2740,20 @@ void putexterns(void)
         exitseg();
         while (globalCache)
         {
-            SYMBOL* sp = (SYMBOL *)globalCache->data;
+            SYMBOL* sp = (SYMBOL*)globalCache->data;
             globaldef(sp);
             globalCache = globalCache->next;
         }
         while (externList)
         {
-            SYMBOL* sp = (SYMBOL *)externList->data;
-           if (!sp->ispure &&
+            SYMBOL* sp = (SYMBOL*)externList->data;
+            if (!sp->ispure &&
                 ((sp->dontinstantiate && sp->genreffed) ||
                  (!sp->inlineFunc.stmt && !sp->init &&
-                     (isfunction(sp->tp) || (!isfunction(sp->tp) && sp->storage_class != sc_global &&
-                                                sp->storage_class != sc_static && sp->storage_class != sc_localstatic)) &&
-                     ((sp->parentClass && sp->genreffed) || (sp->genreffed && sp->storage_class == sc_external)))) &&
-                    !sp->noextern)
+                  (isfunction(sp->tp) || (!isfunction(sp->tp) && sp->storage_class != sc_global && sp->storage_class != sc_static &&
+                                          sp->storage_class != sc_localstatic)) &&
+                  ((sp->parentClass && sp->genreffed) || (sp->genreffed && sp->storage_class == sc_external)))) &&
+                !sp->noextern)
             {
                 notyet = put_exfunc(sp, notyet);
                 sp->genreffed = false;
@@ -2775,7 +2767,7 @@ void putexterns(void)
         while (libincludes)
         {
             if (chosenAssembler->gen->output_includelib)
-                chosenAssembler->gen->output_includelib((char *)libincludes->data);
+                chosenAssembler->gen->output_includelib((char*)libincludes->data);
 
             oprintf(icdFile, "\tINCLUDELIB\t%s\n", libincludes->data);
             libincludes = libincludes->next;

--- a/src/occ/middle/ipeep.cpp
+++ b/src/occ/middle/ipeep.cpp
@@ -1,25 +1,25 @@
 /* Software License Agreement
- * 
+ *
  *     Copyright(C) 1994-2019 David Lindauer, (LADSoft)
- * 
+ *
  *     This file is part of the Orange C Compiler package.
- * 
+ *
  *     The Orange C Compiler package is free software: you can redistribute it and/or modify
  *     it under the terms of the GNU General Public License as published by
  *     the Free Software Foundation, either version 3 of the License, or
  *     (at your option) any later version.
- * 
+ *
  *     The Orange C Compiler package is distributed in the hope that it will be useful,
  *     but WITHOUT ANY WARRANTY; without even the implied warranty of
  *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  *     GNU General Public License for more details.
- * 
+ *
  *     You should have received a copy of the GNU General Public License
  *     along with Orange C.  If not, see <http://www.gnu.org/licenses/>.
- * 
+ *
  *     contact information:
  *         email: TouchStone222@runbox.com <David Lindauer>
- * 
+ *
  */
 
 /*
@@ -223,7 +223,7 @@ void kill_labeledgoto(BLOCK* b, QUAD* head)
  */
 {
     QUAD* newhead;
-    BLOCKLIST *bl, **bt;
+    BLOCKLIST** bt;
     int oldlabel = head->dc.v.label;
     (void)b;
     newhead = head->fwd;
@@ -418,7 +418,6 @@ static bool peep(BLOCK* b, bool branches)
  */
 {
     QUAD* head = b->head;
-    BLOCKLIST* bl;
     bool changed = false;
     if (b->visiteddfst)
         return changed;
@@ -501,7 +500,7 @@ void peep_icode(bool branches)
 {
     int i;
     bool changed;
-    golist = (QUAD **)oAlloc(sizeof(QUAD*) * (nextLabel - firstLabel));
+    golist = (QUAD**)oAlloc(sizeof(QUAD*) * (nextLabel - firstLabel));
     scan_gotos(intermed_head);
     scan_abnormal();
     for (i = 0; i < blockCount; i++)

--- a/src/occ/middle/irc.cpp
+++ b/src/occ/middle/irc.cpp
@@ -578,7 +578,7 @@ int SqueezeChange(int temp, int t, int delta)
         if (delta >= 0)
             delta = std::max(0, std::min(delta, tempInfo[temp]->regClass->saturationBound[v->index] - alpha));
         else
-            delta = std::max(0, std::min(delta, delta - (tempInfo[temp]->regClass->saturationBound[v->index] - alpha)));
+            delta = std::min(0, std::max(delta, delta - (tempInfo[temp]->regClass->saturationBound[v->index] - alpha)));
 
         v = v->parent;
     } while (delta && v);

--- a/src/occ/middle/ireshape.cpp
+++ b/src/occ/middle/ireshape.cpp
@@ -202,7 +202,6 @@ static bool GatherExpression(int tx, RESHAPE_EXPRESSION* expr, int flags)
             {
                 int tnum = ins->dc.left->offset->v.sp->value.i;
                 int flags1 = flags;
-                RESHAPE_LIST* re;
                 if (ins->dc.opcode == i_sub)
                     flags ^= RF_NEG;
 
@@ -219,7 +218,6 @@ static bool GatherExpression(int tx, RESHAPE_EXPRESSION* expr, int flags)
             {
                 int tnum = ins->dc.right->offset->v.sp->value.i;
                 int flags1 = flags;
-                RESHAPE_LIST* re;
                 if (ins->dc.opcode == i_sub)
                     flags ^= RF_NEG;
                 flags |= (ins->dc.opcode == i_lsl ? RF_SHIFT : 0);
@@ -544,7 +542,7 @@ static IMODE* InsertMulInstruction(BLOCK* b, int size, QUAD* insertBefore, int f
     {
         if (iml->mode == i_immed && isintconst(iml->offset))
         {
-            iml->offset->v.i = (1 << iml->offset->v.i);
+            iml->offset->v.i = (1ULL << iml->offset->v.i);
         }
         else
         {
@@ -686,7 +684,6 @@ static IMODE* RewriteDistributed(BLOCK* b, int size, IMODE* im, QUAD* ia, RESHAP
 {
     IMODE* total = distrib->lastDistribName;
     RESHAPE_LIST* gather = distrib;
-    int flagsr;
     while (gather &&
            (!b || gather->im->mode == i_immed ||
             (!variantThisLoop(b, gather->im->offset->v.sp->value.i) && usedThisLoop(b, gather->im->offset->v.sp->value.i))))

--- a/src/occ/middle/issa.cpp
+++ b/src/occ/middle/issa.cpp
@@ -99,7 +99,6 @@ static void insertPhiOp(BLOCK* b, int tnum)
     PHIDATA* phi = (PHIDATA *) oAlloc(sizeof(PHIDATA));
     BLOCKLIST* pred = b->pred;
     struct _phiblock** pbhold;
-    LIST* list;
     phi->T0 = tnum;
     q->dc.opcode = i_phi;
     q->dc.v.phi = phi;
@@ -119,7 +118,6 @@ static void insertPhiOp(BLOCK* b, int tnum)
     while (pred)
     {
         struct _phiblock* pb = (_phiblock *)oAlloc(sizeof(struct _phiblock));
-        LIST* list;
         phi->nblocks++;
         *pbhold = pb;
         pbhold = &(*pbhold)->next;
@@ -281,8 +279,7 @@ static void renameToPhi(BLOCK* b)
     /* go through the code in the block in forward order */
     while (!done)
     {
-        IMODE *im, *found;
-        QUAD* q;
+        IMODE *im;
         /* these always come first, which satisfies renaming the T0s
          * before doing further processing of the block
          */
@@ -459,7 +456,6 @@ static void renameToPhi(BLOCK* b)
                     {
                         TEMP_INFO* t = tempInfo[(int)tempInfo[tnum]->renameStack->data];
                         IMODE* im;
-                        LIST* l;
                         tempInfo[tnum]->renameStack = tempInfo[tnum]->renameStack->next;
                         if (tail->dead)
                         {
@@ -727,7 +723,6 @@ static void CoalesceTemps(LOOP* l, bool all)
 }
 static void partition(bool all)
 {
-    int i;
     BRIGGS_SET* copied = briggsAlloc(tempCount * 2);
     findCopies(copied, all);
     // each temp was partitioned to itself when we allocated the temp

--- a/src/occ/middle/istmt.cpp
+++ b/src/occ/middle/istmt.cpp
@@ -176,7 +176,6 @@ IMODE* set_symbol(const char* name, int isproc)
     sp = gsearch(name);
     if (sp == 0)
     {
-        LIST* l1;
         IncGlobalFlag();
         sp = (SYMBOL*)(SYMBOL *)Alloc(sizeof(SYMBOL));
         sp->storage_class = sc_external;
@@ -331,7 +330,6 @@ void genxswitch(STATEMENT* stmt, SYMBOL* funcsp)
     ap = LookupLoadTemp(NULL, ap3);
     if (ap != ap3)
     {
-        IMODE* barrier;
 //        if (stmt->select->isatomic)
 //        {
 //            barrier = doatomicFence(funcsp, NULL, stmt->select, NULL);
@@ -529,7 +527,6 @@ void genreturn(STATEMENT* stmt, SYMBOL* funcsp, int flag, int noepilogue, IMODE*
             ap = LookupLoadTemp(NULL, ap3);
             if (ap != ap3)
             {
-                IMODE* barrier;
 //                if (stmt->select->isatomic)
 //                {
 //                    barrier = doatomicFence(funcsp, NULL, stmt->select, NULL);
@@ -576,7 +573,7 @@ void genreturn(STATEMENT* stmt, SYMBOL* funcsp, int flag, int noepilogue, IMODE*
         {
             retsize = funcsp->paramsize;
         }
-        if (1 || !inlinesym_count || (!noepilogue && funcsp->retcount > 1))
+        if (!inlinesym_count || (!noepilogue && funcsp->retcount > 1))// originally was always true, removing as a test
         {
             gen_label(retlab);
         }

--- a/src/occ/middle/istmt.cpp
+++ b/src/occ/middle/istmt.cpp
@@ -110,7 +110,7 @@ IMODE* tempreg(int size, int mode)
  */
 {
     IMODE* ap;
-    ap = (IMODE*)(IMODE *)Alloc(sizeof(IMODE));
+    ap = (IMODE*)Alloc(sizeof(IMODE));
     ap->offset = tempenode();
     ap->offset->v.sp->tp = (TYPE *)Alloc(sizeof(TYPE));
     ap->offset->v.sp->tp->type = bt_int;
@@ -135,7 +135,7 @@ IMODE* imake_label(int label)
  */
 
 {
-    IMODE* ap = (IMODE*)(IMODE *)Alloc(sizeof(IMODE));
+    IMODE* ap = (IMODE*)Alloc(sizeof(IMODE));
     ap->mode = i_immed;
     ap->offset = exprNode(en_labcon, NULL, NULL);
     ap->offset->v.i = label;
@@ -177,11 +177,11 @@ IMODE* set_symbol(const char* name, int isproc)
     if (sp == 0)
     {
         IncGlobalFlag();
-        sp = (SYMBOL*)(SYMBOL *)Alloc(sizeof(SYMBOL));
+        sp = (SYMBOL*)Alloc(sizeof(SYMBOL));
         sp->storage_class = sc_external;
         sp->name = sp->errname = sp->decoratedName = litlate(name);
         GENREF(sp);
-        sp->tp = (TYPE*)(TYPE *)Alloc(sizeof(TYPE));
+        sp->tp = (TYPE*)Alloc(sizeof(TYPE));
         sp->tp->type = isproc ? bt_func : bt_int;
         sp->safefunc = true;
         insert(sp, globalNameSpace->syms);
@@ -193,7 +193,7 @@ IMODE* set_symbol(const char* name, int isproc)
         if (sp->storage_class == sc_overloads)
             sp = (SYMBOL*)(sp->tp->syms->table[0]->p);
     }
-    result = (IMODE*)(IMODE *)Alloc(sizeof(IMODE));
+    result = (IMODE*)Alloc(sizeof(IMODE));
     result->offset = varNode(en_global, sp);
     result->mode = i_direct;
     if (isproc)
@@ -436,10 +436,10 @@ static STATEMENT* gen___try(SYMBOL* funcsp, STATEMENT* stmt)
                 mode = 2;
                 if (stmt->sym)
                 {
-                    left = (IMODE*)(IMODE *)Alloc(sizeof(IMODE));
+                    left = (IMODE*)Alloc(sizeof(IMODE));
                     left->mode = i_direct;
                     left->size = ISZ_OBJECT;
-                    left->offset = (EXPRESSION*)(EXPRESSION *)Alloc(sizeof(EXPRESSION));
+                    left->offset = (EXPRESSION*)Alloc(sizeof(EXPRESSION));
                     left->offset->type = en_auto;
                     left->offset->v.sp = stmt->sym;
                 }
@@ -635,7 +635,7 @@ void genreturn(STATEMENT* stmt, SYMBOL* funcsp, int flag, int noepilogue, IMODE*
 
 void gen_varstart(void* exp)
 {
-    IMODE* ap = (IMODE*)(IMODE *)Alloc(sizeof(IMODE));
+    IMODE* ap = (IMODE*)Alloc(sizeof(IMODE));
     ap->mode = i_immed;
     ap->offset = (expr *)exp;
     ap->size = ISZ_ADDR;
@@ -643,7 +643,7 @@ void gen_varstart(void* exp)
 }
 void gen_func(void* exp, int start)
 {
-    IMODE* ap = (IMODE*)(IMODE *)Alloc(sizeof(IMODE));
+    IMODE* ap = (IMODE*)Alloc(sizeof(IMODE));
     ap->mode = i_immed;
     ap->offset = (expr *)exp;
     ap->size = ISZ_ADDR;
@@ -977,7 +977,7 @@ static void InsertParameterThunks(SYMBOL* funcsp, BLOCK* b)
         }
         if (funcsp->oldstyle && sp->tp->type == bt_float)
         {
-            IMODE* right = (IMODE*)(IMODE *)Alloc(sizeof(IMODE));
+            IMODE* right = (IMODE*)Alloc(sizeof(IMODE));
             *right = *sp->imvalue;
             right->size = ISZ_DOUBLE;
             if (!chosenAssembler->arch->hasFloatRegs)

--- a/src/occ/middle/istmt.cpp
+++ b/src/occ/middle/istmt.cpp
@@ -573,7 +573,7 @@ void genreturn(STATEMENT* stmt, SYMBOL* funcsp, int flag, int noepilogue, IMODE*
         {
             retsize = funcsp->paramsize;
         }
-        if (!inlinesym_count || (!noepilogue && funcsp->retcount > 1))// originally was always true, removing as a test
+        if (1 || !inlinesym_count || (!noepilogue && funcsp->retcount > 1))// originally was always true, removing as a test
         {
             gen_label(retlab);
         }

--- a/src/occ/middle/istren.cpp
+++ b/src/occ/middle/istren.cpp
@@ -120,7 +120,7 @@ static void ScanVarStrength(INSTRUCTIONLIST* l, IMODE* multiplier, int tnum, int
                             {
                                 if (!multiplier)
                                 {
-                                    multiplier = make_immed(head->dc.right->size, 1 << head->dc.right->offset->v.i);
+                                    multiplier = make_immed(head->dc.right->size, 1ULL << head->dc.right->offset->v.i);
                                     tr = head->ans->offset->v.sp->value.i;
                                     ans = head->ans;
                                     ScanVarStrength(tempInfo[tr]->instructionUses, multiplier, tnum, tr, vars);
@@ -129,7 +129,7 @@ static void ScanVarStrength(INSTRUCTIONLIST* l, IMODE* multiplier, int tnum, int
                                 else if (multiplier->mode == i_immed)
                                 {
                                     multiplier =
-                                        make_immed(multiplier->size, (1 << head->dc.right->offset->v.i) * multiplier->offset->v.i);
+                                        make_immed(multiplier->size, (1ULL << head->dc.right->offset->v.i) * multiplier->offset->v.i);
                                     tr = head->ans->offset->v.sp->value.i;
                                     ans = head->ans;
                                     ScanVarStrength(tempInfo[tr]->instructionUses, multiplier, tnum, tr, vars);
@@ -380,7 +380,6 @@ static void DoCompare(QUAD* head, IMODE** temp, IMODE** cnst)
         USES_STRENGTH* sl;
         int n = working->offset->v.sp->value.i;
 
-        int il;
         //		if (tempInfo[n]->oldInductionVar >= 0)
         //			n = tempInfo[n]->oldInductionVar;
         sl = tempInfo[n]->sl;

--- a/src/occ/occ.vcxproj
+++ b/src/occ/occ.vcxproj
@@ -202,7 +202,6 @@
     <ClCompile Include="parse\constopt.cpp" />
     <ClCompile Include="parse\cppbltin.cpp" />
     <ClCompile Include="parse\cpplookup.cpp" />
-    <ClCompile Include="parse\crc32.cpp" />
     <ClCompile Include="parse\debug.cpp" />
     <ClCompile Include="parse\declare.cpp" />
     <ClCompile Include="parse\declcons.cpp" />
@@ -271,6 +270,7 @@
     <ClInclude Include="x86\Cvinfo.h" />
     <ClInclude Include="x86\dbgtypes.h" />
     <ClInclude Include="x86\x86regs.h" />
+    <ClInclude Include="parse\crc32.hpp" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\oasm\oasm.vcxproj">

--- a/src/occ/occ.vcxproj
+++ b/src/occ/occ.vcxproj
@@ -88,6 +88,7 @@
       <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;WIN32;USE_LONGLONG;BORLAND;MICROSOFT;_CRT_SECURE_NO_WARNINGS;x64;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>parse;preproc;middle;x86;..\ocpp;..\oasm;..\util;..\objlib</AdditionalIncludeDirectories>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
+      <ConformanceMode>true</ConformanceMode>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>

--- a/src/occ/occ.vcxproj.filters
+++ b/src/occ/occ.vcxproj.filters
@@ -239,9 +239,6 @@
     <ClCompile Include="..\oasm\AsmLexer.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
-    <ClCompile Include="parse\crc32.cpp">
-      <Filter>Source Files</Filter>
-    </ClCompile>
     <ClCompile Include="x86\x64Parser.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
@@ -253,6 +250,9 @@
     </ClCompile>
   </ItemGroup>
   <ItemGroup>
+    <ClInclude Include="parse\crc32.hpp">
+      <Filter>Header Files</Filter>
+    </ClInclude>
     <ClInclude Include="parse\beinterf.h">
       <Filter>Header Files</Filter>
     </ClInclude>

--- a/src/occ/parse/beinterf.cpp
+++ b/src/occ/parse/beinterf.cpp
@@ -1,25 +1,25 @@
 /* Software License Agreement
- * 
+ *
  *     Copyright(C) 1994-2019 David Lindauer, (LADSoft)
- * 
+ *
  *     This file is part of the Orange C Compiler package.
- * 
+ *
  *     The Orange C Compiler package is free software: you can redistribute it and/or modify
  *     it under the terms of the GNU General Public License as published by
  *     the Free Software Foundation, either version 3 of the License, or
  *     (at your option) any later version.
- * 
+ *
  *     The Orange C Compiler package is distributed in the hope that it will be useful,
  *     but WITHOUT ANY WARRANTY; without even the implied warranty of
  *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  *     GNU General Public License for more details.
- * 
+ *
  *     You should have received a copy of the GNU General Public License
  *     along with Orange C.  If not, see <http://www.gnu.org/licenses/>.
- * 
+ *
  *     contact information:
  *         email: TouchStone222@runbox.com <David Lindauer>
- * 
+ *
  */
 
 /*
@@ -383,7 +383,7 @@ int needsAtomicLockFromType(TYPE* tp)
     }
 }
 static int basesize(ARCH_SIZING* p, TYPE* tp)
-{   
+{
     tp = basetype(tp);
     switch (tp->type)
     {
@@ -466,8 +466,7 @@ static int basesize(ARCH_SIZING* p, TYPE* tp)
 }
 int getSize(enum e_bt type)
 {
-    TYPE tp;
-    memset(&tp, 0, sizeof(tp));
+    TYPE tp{};
     tp.type = type; /* other fields don't matter, we never call this for structured types*/
     return basesize(chosenAssembler->arch->type_sizes, &tp);
 }
@@ -485,8 +484,7 @@ long getautoval(long val)
 {
     if (chosenAssembler->arch->spgrowsup)
         return -val;
-    else
-        return val;
+    return val;
 }
 int funcvaluesize(int val)
 {

--- a/src/occ/parse/c.h
+++ b/src/occ/parse/c.h
@@ -542,7 +542,7 @@ struct xcept
     EXPRESSION* xcRundownFunc;
 };
 
-typedef struct attributes
+struct attributes
 {
     struct {
         int structAlign;                                      /* alignment of structures/ unions */

--- a/src/occ/parse/ccerr.cpp
+++ b/src/occ/parse/ccerr.cpp
@@ -1629,8 +1629,6 @@ static void validateGotos(VLASHIM* shim, VLASHIM* root)
 {
     while (shim)
     {
-        VLASHIM* selected;
-        LIST* prev;
         switch (shim->type)
         {
             case v_blockstart:

--- a/src/occ/parse/ccerr.cpp
+++ b/src/occ/parse/ccerr.cpp
@@ -1396,7 +1396,7 @@ static VLASHIM* mkshim(_vlaTypes type, int level, int label, STATEMENT* stmt, VL
     VLASHIM* rv = (VLASHIM *)Alloc(sizeof(VLASHIM));
     if (last && last->type != v_return && last->type != v_goto)
     {
-        rv->backs = (LIST*)(LIST *)Alloc(sizeof(LIST));
+        rv->backs = (LIST*)Alloc(sizeof(LIST));
         rv->backs->data = last;
     }
     rv->type = type;
@@ -1554,7 +1554,7 @@ static void fillPrevious(VLASHIM* shim, VLASHIM** labels, int minLabel)
                 selected = labels[shim->label - minLabel];
                 if (selected)
                 {
-                    prev = (LIST*)(LIST *)Alloc(sizeof(LIST));
+                    prev = (LIST*)Alloc(sizeof(LIST));
                     prev->data = shim;
                     prev->next = selected->backs;
                     selected->backs = prev;

--- a/src/occ/parse/compiler.h
+++ b/src/occ/parse/compiler.h
@@ -1,25 +1,25 @@
 /* Software License Agreement
- * 
+ *
  *     Copyright(C) 1994-2019 David Lindauer, (LADSoft)
- * 
+ *
  *     This file is part of the Orange C Compiler package.
- * 
+ *
  *     The Orange C Compiler package is free software: you can redistribute it and/or modify
  *     it under the terms of the GNU General Public License as published by
  *     the Free Software Foundation, either version 3 of the License, or
  *     (at your option) any later version.
- * 
+ *
  *     The Orange C Compiler package is distributed in the hope that it will be useful,
  *     but WITHOUT ANY WARRANTY; without even the implied warranty of
  *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  *     GNU General Public License for more details.
- * 
+ *
  *     You should have received a copy of the GNU General Public License
  *     along with Orange C.  If not, see <http://www.gnu.org/licenses/>.
- * 
+ *
  *     contact information:
  *         email: TouchStone222@runbox.com <David Lindauer>
- * 
+ *
  */
 
 /* the long long type is 8 bytes...  if neither long long nor the long type is 8 byte in the compiler
@@ -31,9 +31,6 @@
 #    ifdef BORLAND
 #        define ULLONG_TYPE unsigned __int64
 #        define LLONG_TYPE __int64
-#        define LLONG_MIN _I64_MIN
-#        define LLONG_MAX _I64_MAX
-#        define ULLONG_MAX ((_I64_MAX << 1) + 1)
 #    else
 #        define ULLONG_TYPE unsigned long long
 #        define LLONG_TYPE long long
@@ -42,7 +39,6 @@
 #else
 #    define ULLONG_TYPE unsigned long
 #    define LLONG_TYPE long
-#    define ULLONG_MAX ULONG_MAX
 #    define LLONG_FORMAT_SPECIFIER "%ld"
 #endif
 

--- a/src/occ/parse/compiler.p
+++ b/src/occ/parse/compiler.p
@@ -105,9 +105,6 @@ void optimize_for_constants(EXPRESSION* *expr);
 LEXEME* optimized_expression(LEXEME* lex, SYMBOL* funcsp, TYPE* atp, TYPE* *tp, 
 	EXPRESSION* *expr, bool commaallowed);
 
-                               /* CRC.C */
-
-unsigned CRC32(unsigned char* data, size_t len);
 
                                /* Debug.c */
 

--- a/src/occ/parse/compiler.p
+++ b/src/occ/parse/compiler.p
@@ -809,7 +809,7 @@ char* litlate(const char* name);
 LCHAR* wlitlate(const LCHAR* name);
 
                               /* Osutil.c */
-
+[[noreturn]]
 void fatal(const char* fmt, ...);
 void banner(const char* fmt, ...);
 void usage(char* prog_name);

--- a/src/occ/parse/cpplookup.cpp
+++ b/src/occ/parse/cpplookup.cpp
@@ -348,10 +348,10 @@ LEXEME* nestedPath(LEXEME* lex, SYMBOL** sym, NAMESPACEVALUES** ns, bool* throug
                                     break;
                                 lex = getsym();
                                 finalPos = lex;
-                                *last = (TEMPLATESELECTOR*)(TEMPLATESELECTOR *)Alloc(sizeof(TEMPLATESELECTOR));
+                                *last = (TEMPLATESELECTOR*)Alloc(sizeof(TEMPLATESELECTOR));
                                 (*last)->sym = sp;
                                 last = &(*last)->next;
-                                *last = (TEMPLATESELECTOR*)(TEMPLATESELECTOR *)Alloc(sizeof(TEMPLATESELECTOR));
+                                *last = (TEMPLATESELECTOR*)Alloc(sizeof(TEMPLATESELECTOR));
                                 (*last)->sym = sp;
                                 (*last)->templateParams = current;
                                 (*last)->isTemplate = true;
@@ -406,10 +406,10 @@ LEXEME* nestedPath(LEXEME* lex, SYMBOL** sym, NAMESPACEVALUES** ns, bool* throug
                 dropStructureDeclaration();
                 if (!sp && templateNestingCount)
                 {
-                    *last = (TEMPLATESELECTOR*)(TEMPLATESELECTOR *)Alloc(sizeof(TEMPLATESELECTOR));
+                    *last = (TEMPLATESELECTOR*)Alloc(sizeof(TEMPLATESELECTOR));
                     (*last)->sym = NULL;
                     last = &(*last)->next;
-                    *last = (TEMPLATESELECTOR*)(TEMPLATESELECTOR *)Alloc(sizeof(TEMPLATESELECTOR));
+                    *last = (TEMPLATESELECTOR*)Alloc(sizeof(TEMPLATESELECTOR));
                     (*last)->sym = strSym;
                     (*last)->templateParams = current;
                     (*last)->isTemplate = true;
@@ -598,7 +598,7 @@ LEXEME* nestedPath(LEXEME* lex, SYMBOL** sym, NAMESPACEVALUES** ns, bool* throug
                         TEMPLATESELECTOR* s = basetype(sp->tp)->sp->templateSelector;
                         while (s)
                         {
-                            *last = (TEMPLATESELECTOR*)(TEMPLATESELECTOR *)Alloc(sizeof(TEMPLATESELECTOR));
+                            *last = (TEMPLATESELECTOR*)Alloc(sizeof(TEMPLATESELECTOR));
                             **last = *s;
                             last = &(*last)->next;
                             s = s->next;
@@ -608,10 +608,10 @@ LEXEME* nestedPath(LEXEME* lex, SYMBOL** sym, NAMESPACEVALUES** ns, bool* throug
                     }
                     else
                     {
-                        *last = (TEMPLATESELECTOR*)(TEMPLATESELECTOR *)Alloc(sizeof(TEMPLATESELECTOR));
+                        *last = (TEMPLATESELECTOR*)Alloc(sizeof(TEMPLATESELECTOR));
                         (*last)->sym = strSym;
                         last = &(*last)->next;
-                        *last = (TEMPLATESELECTOR*)(TEMPLATESELECTOR *)Alloc(sizeof(TEMPLATESELECTOR));
+                        *last = (TEMPLATESELECTOR*)Alloc(sizeof(TEMPLATESELECTOR));
                         (*last)->sym = sp;
                         (*last)->templateParams = current;
                         (*last)->isTemplate = true;

--- a/src/occ/parse/crc32.hpp
+++ b/src/occ/parse/crc32.hpp
@@ -1,5 +1,5 @@
 #include <stdlib.h>
-unsigned crctab[256] = {
+constexpr unsigned crctab[256] = {
     0xd202ef8d, 0xa505df1b, 0x3c0c8ea1, 0x4b0bbe37, 0xd56f2b94, 0xa2681b02, 0x3b614ab8, 0x4c667a2e, 0xdcd967bf, 0xabde5729,
     0x32d70693, 0x45d03605, 0xdbb4a3a6, 0xacb39330, 0x35bac28a, 0x42bdf21c, 0xcfb5ffe9, 0xb8b2cf7f, 0x21bb9ec5, 0x56bcae53,
     0xc8d83bf0, 0xbfdf0b66, 0x26d65adc, 0x51d16a4a, 0xc16e77db, 0xb669474d, 0x2f6016f7, 0x58672661, 0xc603b3c2, 0xb1048354,
@@ -28,11 +28,15 @@ unsigned crctab[256] = {
     0x8f6af48f, 0xf86dc419, 0x660951ba, 0x110e612c, 0x88073096, 0xff000000,
 };
 
-unsigned PartialCRC32(unsigned crc, unsigned char* data, size_t len)
+constexpr unsigned PartialCRC32(unsigned crc, unsigned char* data, size_t len)
 {
-    size_t i;
-    for (i = 0; i < len; ++i)
+    for (size_t i = 0; i < len; ++i)
         crc = crctab[(unsigned char)crc ^ data[i]] ^ crc >> 8;
     return crc;
 }
-unsigned CRC32(unsigned char* data, size_t len) { return PartialCRC32(0, data, len); }
+constexpr unsigned CRC32(unsigned char* data, size_t len) { return PartialCRC32(0, data, len); }
+template <size_t length>
+constexpr unsigned CRC32(unsigned char data[length])
+{
+    return CRC32(data, length);
+}

--- a/src/occ/parse/declare.cpp
+++ b/src/occ/parse/declare.cpp
@@ -1840,7 +1840,6 @@ static LEXEME* getPointerQualifiers(LEXEME* lex, TYPE** tp, bool allowstatic)
     while (KWTYPE(lex, TT_TYPEQUAL) || (allowstatic && MATCHKW(lex, kw_static)))
     {
         TYPE* tpn;
-        TYPE* tpl;
         if (MATCHKW(lex, kw__intrinsic))
         {
             lex = getsym();
@@ -2118,7 +2117,6 @@ LEXEME* getBasicType(LEXEME* lex, SYMBOL* funcsp, TYPE** tp, SYMBOL** strSym_out
     TYPE* tn = NULL;
     TYPE* quals = NULL;
     TYPE** tl;
-    bool extended;
     bool iscomplex = false;
     bool imaginary = false;
     bool flagerror = false;

--- a/src/occ/parse/declare.cpp
+++ b/src/occ/parse/declare.cpp
@@ -23,6 +23,7 @@
  */
 
 #include "compiler.h"
+#include "crc32.hpp"
 #include <wchar.h>
 /* locally declared func gloabal memory
  when redeclaring sym, make sure it gets in the global func list
@@ -225,7 +226,7 @@ void InsertSymbol(SYMBOL* sp, enum e_sc storage_class, enum e_lk linkage, bool a
                 funcs = (SYMBOL*)(*hr)->p;
             if (!funcs)
             {
-                TYPE* tp = (TYPE*)(TYPE *)Alloc(sizeof(TYPE));
+                TYPE* tp = (TYPE*)Alloc(sizeof(TYPE));
                 tp->type = bt_aggregate;
                 tp->rootType = tp;
                 funcs = makeID(sc_overloads, tp, 0, name);
@@ -2651,20 +2652,20 @@ founddecltype:
                                     {
                                         TEMPLATEPARAMLIST *told, **tnew;
                                         sp1 = clonesym(sp);
-                                        sp1->tp = (TYPE*)(TYPE *)Alloc(sizeof(TYPE));
+                                        sp1->tp = (TYPE*)Alloc(sizeof(TYPE));
                                         *sp1->tp = *sp->tp;
                                         sp1->tp->rootType = sp1->tp;
                                         sp1->tp->sp = sp1;
-                                        sp1->tp->templateParam = (TEMPLATEPARAMLIST*)(TEMPLATEPARAMLIST *)Alloc(sizeof(TEMPLATEPARAMLIST));
+                                        sp1->tp->templateParam = (TEMPLATEPARAMLIST*)Alloc(sizeof(TEMPLATEPARAMLIST));
                                         sp1->tp->templateParam->next = sp->tp->templateParam->next;
-                                        sp1->tp->templateParam->p = (TEMPLATEPARAM*)(TEMPLATEPARAM *)Alloc(sizeof(TEMPLATEPARAM));
+                                        sp1->tp->templateParam->p = (TEMPLATEPARAM*)Alloc(sizeof(TEMPLATEPARAM));
                                         *sp1->tp->templateParam->p = *sp->tp->templateParam->p;
                                         tnew = &sp1->tp->templateParam->p->byTemplate.args;
                                         told = *tnew;
                                         sp1->tp->templateParam->p->byTemplate.orig = sp->tp->templateParam;
                                         while (told && lst)
                                         {
-                                            *tnew = (TEMPLATEPARAMLIST*)(TEMPLATEPARAMLIST *)Alloc(sizeof(TEMPLATEPARAMLIST));
+                                            *tnew = (TEMPLATEPARAMLIST*)Alloc(sizeof(TEMPLATEPARAMLIST));
                                             if (told->p->type == kw_new)
                                             {
                                                 (*tnew)->p = told->p;
@@ -3082,7 +3083,7 @@ static LEXEME* getArrayType(LEXEME* lex, SYMBOL* funcsp, TYPE** tp, enum e_sc st
                 error(ERR_QUAL_LAST_ARRAY_ELEMENT);
             lex = getArrayType(lex, funcsp, tp, storage_class, vla, quals, false, msil);
         }
-        tpp = (TYPE*)(TYPE *)Alloc(sizeof(TYPE));
+        tpp = (TYPE*)Alloc(sizeof(TYPE));
         tpp->type = bt_pointer;
         tpp->btp = *tp;
         tpp->btp->msil = msil;  // tag the base type as managed, e.g. so we can't take address of it
@@ -3849,7 +3850,7 @@ LEXEME* getFunctionParams(LEXEME* lex, SYMBOL* funcsp, SYMBOL** spin, TYPE** tp,
                 {
                     if (cparams.prm_c99)
                         errorsym(ERR_MISSING_TYPE_FOR_PARAMETER, spi);
-                    spi->tp = (TYPE*)(TYPE *)Alloc(sizeof(TYPE));
+                    spi->tp = (TYPE*)Alloc(sizeof(TYPE));
                     spi->tp->type = bt_int;
                     spi->tp->size = getSize(bt_int);
                     spi->tp->rootType = spi->tp;
@@ -4926,13 +4927,13 @@ static EXPRESSION* llallocateVLA(SYMBOL* sp, EXPRESSION* ep1, EXPRESSION* ep2)
         }
         if (al && fr)
         {
-            FUNCTIONCALL* epx = (FUNCTIONCALL*)(FUNCTIONCALL *)Alloc(sizeof(FUNCTIONCALL));
-            FUNCTIONCALL* ld = (FUNCTIONCALL*)(FUNCTIONCALL *)Alloc(sizeof(FUNCTIONCALL));
+            FUNCTIONCALL* epx = (FUNCTIONCALL*)Alloc(sizeof(FUNCTIONCALL));
+            FUNCTIONCALL* ld = (FUNCTIONCALL*)Alloc(sizeof(FUNCTIONCALL));
             epx->ascall = true;
             epx->fcall = varNode(en_pc, al);
             epx->sp = al;
             epx->functp = al->tp;
-            epx->arguments = (INITLIST*)(INITLIST *)Alloc(sizeof(INITLIST));
+            epx->arguments = (INITLIST*)Alloc(sizeof(INITLIST));
             epx->arguments->tp = &stdint;
             epx->arguments->exp = ep2;
             ep2 = intNode(en_func, 0);
@@ -4942,7 +4943,7 @@ static EXPRESSION* llallocateVLA(SYMBOL* sp, EXPRESSION* ep1, EXPRESSION* ep2)
             ld->fcall = varNode(en_pc, fr);
             ld->sp = fr;
             ld->functp = fr->tp;
-            ld->arguments = (INITLIST*)(INITLIST *)Alloc(sizeof(INITLIST));
+            ld->arguments = (INITLIST*)Alloc(sizeof(INITLIST));
             ld->arguments->tp = &stdpointer;
             ld->arguments->exp = ep1;
             unloader = intNode(en_func, 0);
@@ -5965,7 +5966,7 @@ LEXEME* declare(LEXEME* lex, SYMBOL* funcsp, TYPE** tprv, enum e_sc storage_clas
                             SYMBOL* special = FindSpecialization(spi, sp->templateParams);
                             if (!special)
                             {
-                                LIST* member = (LIST*)(LIST *)Alloc(sizeof(LIST));
+                                LIST* member = (LIST*)Alloc(sizeof(LIST));
                                 member->data = sp;
                                 member->next = spi->specializations;
                                 spi->specializations = member;

--- a/src/occ/parse/declcons.cpp
+++ b/src/occ/parse/declcons.cpp
@@ -262,7 +262,7 @@ SYMBOL* insertFunc(SYMBOL* sp, SYMBOL* ovl)
         SetLinkerNames(ovl, lk_cdecl);
     if (!funcs)
     {
-        TYPE* tp = (TYPE*)(TYPE *)Alloc(sizeof(TYPE));
+        TYPE* tp = (TYPE*)Alloc(sizeof(TYPE));
         tp->type = bt_aggregate;
         tp->rootType = tp;
         funcs = makeID(sc_overloads, tp, 0, ovl->name);
@@ -292,13 +292,13 @@ static SYMBOL* declareDestructor(SYMBOL* sp)
 {
     SYMBOL* rv;
     SYMBOL *func, *sp1;
-    TYPE* tp = (TYPE*)(TYPE *)Alloc(sizeof(TYPE));
+    TYPE* tp = (TYPE*)Alloc(sizeof(TYPE));
     VBASEENTRY* e;
     BASECLASS* b;
     HASHREC* hr;
     tp->type = bt_func;
     tp->size = getSize(bt_pointer);
-    tp->btp = (TYPE*)(TYPE *)Alloc(sizeof(TYPE));
+    tp->btp = (TYPE*)Alloc(sizeof(TYPE));
     tp->btp->type = bt_void;
     tp->rootType = tp;
     tp->btp->rootType = tp->btp;
@@ -418,10 +418,10 @@ static bool constCopyConstructor(SYMBOL* sp)
 static SYMBOL* declareConstructor(SYMBOL* sp, bool deflt, bool move)
 {
     SYMBOL *func, *sp1;
-    TYPE* tp = (TYPE*)(TYPE *)Alloc(sizeof(TYPE));
+    TYPE* tp = (TYPE*)Alloc(sizeof(TYPE));
     tp->type = bt_func;
     tp->size = getSize(bt_pointer);
-    tp->btp = (TYPE*)(TYPE *)Alloc(sizeof(TYPE));
+    tp->btp = (TYPE*)Alloc(sizeof(TYPE));
     tp->btp->type = bt_void;
     tp->rootType = tp;
     tp->btp->rootType = tp->btp;
@@ -430,9 +430,9 @@ static SYMBOL* declareConstructor(SYMBOL* sp, bool deflt, bool move)
     func->attribs.inheritable.linkage2 = sp->attribs.inheritable.linkage2;
     sp1 = makeID(sc_parameter, NULL, NULL, AnonymousName());
     tp->syms = CreateHashTable(1);
-    tp->syms->table[0] = (HASHREC*)(HASHREC *)Alloc(sizeof(HASHREC));
+    tp->syms->table[0] = (HASHREC*)Alloc(sizeof(HASHREC));
     tp->syms->table[0]->p = (struct sym *)sp1;
-    sp1->tp = (TYPE*)(TYPE *)Alloc(sizeof(TYPE));
+    sp1->tp = (TYPE*)Alloc(sizeof(TYPE));
     if (deflt)
     {
         sp1->tp->type = bt_void;
@@ -443,13 +443,13 @@ static SYMBOL* declareConstructor(SYMBOL* sp, bool deflt, bool move)
         TYPE* tpx = sp1->tp;
         tpx->type = move ? bt_rref : bt_lref;
         tpx->size = getSize(bt_pointer);
-        tpx->btp = (TYPE*)(TYPE *)Alloc(sizeof(TYPE));
+        tpx->btp = (TYPE*)Alloc(sizeof(TYPE));
         tpx = tpx->btp;
         if (constCopyConstructor(sp))
         {
             tpx->type = bt_const;
             tpx->size = getSize(bt_pointer);
-            tpx->btp = (TYPE*)(TYPE *)Alloc(sizeof(TYPE));
+            tpx->btp = (TYPE*)Alloc(sizeof(TYPE));
             tpx = tpx->btp;
         }
         *tpx = *basetype(sp->tp);
@@ -491,17 +491,17 @@ static bool constAssignmentOp(SYMBOL* sp, bool move)
 static SYMBOL* declareAssignmentOp(SYMBOL* sp, bool move)
 {
     SYMBOL *func, *sp1;
-    TYPE* tp = (TYPE*)(TYPE *)Alloc(sizeof(TYPE));
+    TYPE* tp = (TYPE*)Alloc(sizeof(TYPE));
     TYPE* tpx;
     tp->type = bt_func;
     tp->size = getSize(bt_pointer);
-    tp->btp = (TYPE*)(TYPE *)Alloc(sizeof(TYPE));
-    tpx = tp->btp = (TYPE*)(TYPE *)Alloc(sizeof(TYPE));
+    tp->btp = (TYPE*)Alloc(sizeof(TYPE));
+    tpx = tp->btp = (TYPE*)Alloc(sizeof(TYPE));
     if (isstructured(sp->tp))
     {
         tpx->type = move ? bt_rref : bt_lref;
         tpx->size = getSize(bt_pointer);
-        tpx = tpx->btp = (TYPE*)(TYPE *)Alloc(sizeof(TYPE));
+        tpx = tpx->btp = (TYPE*)Alloc(sizeof(TYPE));
     }
     *(tpx) = *basetype(sp->tp);
     UpdateRootTypes(tp);
@@ -509,18 +509,18 @@ static SYMBOL* declareAssignmentOp(SYMBOL* sp, bool move)
     func->attribs.inheritable.linkage2 = sp->attribs.inheritable.linkage2;
     sp1 = makeID(sc_parameter, NULL, NULL, AnonymousName());
     tp->syms = CreateHashTable(1);
-    tp->syms->table[0] = (HASHREC*)(HASHREC *)Alloc(sizeof(HASHREC));
+    tp->syms->table[0] = (HASHREC*)Alloc(sizeof(HASHREC));
     tp->syms->table[0]->p = (struct sym *)sp1;
-    sp1->tp = (TYPE*)(TYPE *)Alloc(sizeof(TYPE));
+    sp1->tp = (TYPE*)Alloc(sizeof(TYPE));
     tpx = sp1->tp;
     tpx->type = move ? bt_rref : bt_lref;
-    tpx->btp = (TYPE*)(TYPE *)Alloc(sizeof(TYPE));
+    tpx->btp = (TYPE*)Alloc(sizeof(TYPE));
     tpx = tpx->btp;
     if (constAssignmentOp(sp, move))
     {
         tpx->type = bt_const;
         tpx->size = getSize(bt_pointer);
-        tpx->btp = (TYPE*)(TYPE *)Alloc(sizeof(TYPE));
+        tpx->btp = (TYPE*)Alloc(sizeof(TYPE));
         tpx = tpx->btp;
     }
     *tpx = *basetype(sp->tp);
@@ -1328,8 +1328,8 @@ static void shimDefaultConstructor(SYMBOL* sp, SYMBOL* cons)
             AdjustParams(match, basetype(match->tp)->syms->table[0], &params->arguments, false, true);
             if (sp->vbaseEntries)
             {
-                INITLIST *x = (INITLIST*)(INITLIST *)Alloc(sizeof(INITLIST)), **p;
-                x->tp = (TYPE*)(TYPE *)Alloc(sizeof(TYPE));
+                INITLIST *x = (INITLIST*)Alloc(sizeof(INITLIST)), **p;
+                x->tp = (TYPE*)Alloc(sizeof(TYPE));
                 x->tp->type = bt_int;
                 x->tp->rootType = x->tp;
                 x->tp->size = getSize(bt_int);
@@ -1609,7 +1609,7 @@ static void genConstructorCall(BLOCKDATA* b, SYMBOL* cls, MEMBERINITIALIZERS* mi
             }
             else
             {
-                TYPE* tp = (TYPE*)(TYPE *)Alloc(sizeof(TYPE));
+                TYPE* tp = (TYPE*)Alloc(sizeof(TYPE));
                 EXPRESSION* other = exprNode(en_add, otherptr, intNode(en_c_i, memberOffs));
                 if (basetype(parentCons->tp)->type == bt_rref)
                     other = exprNode(en_not_lvalue, other, NULL);
@@ -1648,7 +1648,7 @@ static void genConstructorCall(BLOCKDATA* b, SYMBOL* cls, MEMBERINITIALIZERS* mi
             }
             else
             {
-                TYPE* tp = (TYPE*)(TYPE *)Alloc(sizeof(TYPE));
+                TYPE* tp = (TYPE*)Alloc(sizeof(TYPE));
                 EXPRESSION* other = exprNode(en_add, otherptr, intNode(en_c_i, memberOffs));
                 if (basetype(parentCons->tp)->type == bt_rref)
                     other = exprNode(en_not_lvalue, other, NULL);
@@ -1699,11 +1699,11 @@ static void genConstructorCall(BLOCKDATA* b, SYMBOL* cls, MEMBERINITIALIZERS* mi
             if (mi)
             {
                 INITIALIZER* init = mi->init;
-                FUNCTIONCALL* funcparams = (FUNCTIONCALL*)(FUNCTIONCALL *)Alloc(sizeof(FUNCTIONCALL));
+                FUNCTIONCALL* funcparams = (FUNCTIONCALL*)Alloc(sizeof(FUNCTIONCALL));
                 INITLIST** args = &funcparams->arguments;
                 while (init && init->exp)
                 {
-                    *args = (INITLIST*)(INITLIST *)Alloc(sizeof(INITLIST));
+                    *args = (INITLIST*)Alloc(sizeof(INITLIST));
                     (*args)->tp = init->basetp;
                     (*args)->exp = init->exp;
                     args = &(*args)->next;
@@ -2109,7 +2109,7 @@ void ParseMemberInitializers(SYMBOL* cls, SYMBOL* cons)
                             SetAlternateLex(NULL);
                             while (shim.arguments)
                             {
-                                *xinit = (INITIALIZER*)(INITIALIZER *)Alloc(sizeof(INITIALIZER));
+                                *xinit = (INITIALIZER*)Alloc(sizeof(INITIALIZER));
                                 (*xinit)->basetp = shim.arguments->tp;
                                 (*xinit)->exp = shim.arguments->exp;
                                 xinit = &(*xinit)->next;
@@ -2184,7 +2184,7 @@ void ParseMemberInitializers(SYMBOL* cls, SYMBOL* cons)
                     }
                     while (shim.arguments)
                     {
-                        *xinit = (INITIALIZER*)(INITIALIZER *)Alloc(sizeof(INITIALIZER));
+                        *xinit = (INITIALIZER*)Alloc(sizeof(INITIALIZER));
                         (*xinit)->basetp = shim.arguments->tp;
                         (*xinit)->exp = shim.arguments->exp;
                         xinit = &(*xinit)->next;
@@ -2242,7 +2242,7 @@ void ParseMemberInitializers(SYMBOL* cls, SYMBOL* cons)
                         SetAlternateLex(NULL);
                         while (shim.arguments)
                         {
-                            *xinit = (INITIALIZER*)(INITIALIZER *)Alloc(sizeof(INITIALIZER));
+                            *xinit = (INITIALIZER*)Alloc(sizeof(INITIALIZER));
                             (*xinit)->basetp = shim.arguments->tp;
                             (*xinit)->exp = shim.arguments->exp;
                             xinit = &(*xinit)->next;
@@ -2493,8 +2493,8 @@ static void genAsnCall(BLOCKDATA* b, SYMBOL* cls, SYMBOL* base, int offset, EXPR
     (void)cls;
     EXPRESSION* exp = NULL;
     STATEMENT* st;
-    FUNCTIONCALL* params = (FUNCTIONCALL*)(FUNCTIONCALL *)Alloc(sizeof(FUNCTIONCALL));
-    TYPE* tp = (TYPE*)(TYPE *)Alloc(sizeof(TYPE));
+    FUNCTIONCALL* params = (FUNCTIONCALL*)Alloc(sizeof(FUNCTIONCALL));
+    TYPE* tp = (TYPE*)Alloc(sizeof(TYPE));
     SYMBOL* asn1;
     SYMBOL* cons = search(overloadNameTab[assign - kw_new + CI_NEW], basetype(base->tp)->syms);
     EXPRESSION* left = exprNode(en_add, thisptr, intNode(en_c_i, offset));
@@ -2524,7 +2524,7 @@ static void genAsnCall(BLOCKDATA* b, SYMBOL* cls, SYMBOL* base, int offset, EXPR
         tp->lref = true;
         tp->rref = false;
     }
-    params->arguments = (INITLIST*)(INITLIST *)Alloc(sizeof(INITLIST));
+    params->arguments = (INITLIST*)Alloc(sizeof(INITLIST));
     params->arguments->tp = tp;
     params->arguments->exp = right;
     params->thisptr = left;
@@ -2759,13 +2759,13 @@ void makeArrayConsDest(TYPE** tp, EXPRESSION** exp, SYMBOL* cons, SYMBOL* dest, 
 {
     EXPRESSION* size = intNode(en_c_i, (*tp)->size);
     EXPRESSION *econs = (cons ? varNode(en_pc, cons) : NULL), *edest = varNode(en_pc, dest);
-    FUNCTIONCALL* params = (FUNCTIONCALL*)(FUNCTIONCALL *)Alloc(sizeof(FUNCTIONCALL));
+    FUNCTIONCALL* params = (FUNCTIONCALL*)Alloc(sizeof(FUNCTIONCALL));
     SYMBOL* asn1;
-    INITLIST* arg0 = (INITLIST*)(INITLIST *)Alloc(sizeof(INITLIST));  // this
-    INITLIST* arg1 = (INITLIST*)(INITLIST *)Alloc(sizeof(INITLIST));  // cons
-    INITLIST* arg2 = (INITLIST*)(INITLIST *)Alloc(sizeof(INITLIST));  // dest
-    INITLIST* arg3 = (INITLIST*)(INITLIST *)Alloc(sizeof(INITLIST));  // size
-    INITLIST* arg4 = (INITLIST*)(INITLIST *)Alloc(sizeof(INITLIST));  // count
+    INITLIST* arg0 = (INITLIST*)Alloc(sizeof(INITLIST));  // this
+    INITLIST* arg1 = (INITLIST*)Alloc(sizeof(INITLIST));  // cons
+    INITLIST* arg2 = (INITLIST*)Alloc(sizeof(INITLIST));  // dest
+    INITLIST* arg3 = (INITLIST*)Alloc(sizeof(INITLIST));  // size
+    INITLIST* arg4 = (INITLIST*)Alloc(sizeof(INITLIST));  // count
     SYMBOL* ovl = namespacesearch("__arrCall", globalNameSpace, false, false);
     params->arguments = arg0;
     arg0->next = arg1;
@@ -2809,7 +2809,7 @@ void callDestructor(SYMBOL* sp, SYMBOL* against, EXPRESSION** exp, EXPRESSION* a
     SYMBOL* dest;
     SYMBOL* dest1;
     TYPE *tp = NULL, *stp;
-    FUNCTIONCALL* params = (FUNCTIONCALL*)(FUNCTIONCALL *)Alloc(sizeof(FUNCTIONCALL));
+    FUNCTIONCALL* params = (FUNCTIONCALL*)Alloc(sizeof(FUNCTIONCALL));
     SYMBOL* sym;
     if (!against)
         against = sp;
@@ -2861,8 +2861,8 @@ void callDestructor(SYMBOL* sp, SYMBOL* against, EXPRESSION** exp, EXPRESSION* a
         {
             if (sp->vbaseEntries)
             {
-                INITLIST *x = (INITLIST*)(INITLIST *)Alloc(sizeof(INITLIST)), **p;
-                x->tp = (TYPE*)(TYPE *)Alloc(sizeof(TYPE));
+                INITLIST *x = (INITLIST*)Alloc(sizeof(INITLIST)), **p;
+                x->tp = (TYPE*)Alloc(sizeof(TYPE));
                 x->tp->type = bt_int;
                 x->tp->size = getSize(bt_int);
                 x->tp->rootType = x->tp;
@@ -2912,7 +2912,7 @@ bool callConstructor(TYPE** tp, EXPRESSION** exp, FUNCTIONCALL* params, bool che
 
     if (!params)
     {
-        params = (FUNCTIONCALL*)(FUNCTIONCALL *)Alloc(sizeof(FUNCTIONCALL));
+        params = (FUNCTIONCALL*)Alloc(sizeof(FUNCTIONCALL));
     }
     else
     {
@@ -3031,7 +3031,7 @@ bool callConstructor(TYPE** tp, EXPRESSION** exp, FUNCTIONCALL* params, bool che
                 SYMBOL* dest1;
                 SYMBOL* against = top ? sp : sp->parentClass;
                 TYPE* tp = NULL;
-                FUNCTIONCALL* params = (FUNCTIONCALL*)(FUNCTIONCALL *)Alloc(sizeof(FUNCTIONCALL));
+                FUNCTIONCALL* params = (FUNCTIONCALL*)Alloc(sizeof(FUNCTIONCALL));
                 if (!*exp)
                 {
                     diag("callDestructor: no this pointer");
@@ -3060,8 +3060,8 @@ bool callConstructor(TYPE** tp, EXPRESSION** exp, FUNCTIONCALL* params, bool che
             {
                 if (sp->vbaseEntries)
                 {
-                    INITLIST *x = (INITLIST*)(INITLIST *)Alloc(sizeof(INITLIST)), **p;
-                    x->tp = (TYPE*)(TYPE *)Alloc(sizeof(TYPE));
+                    INITLIST *x = (INITLIST*)Alloc(sizeof(INITLIST)), **p;
+                    x->tp = (TYPE*)Alloc(sizeof(TYPE));
                     x->tp->type = bt_int;
                     x->tp->rootType = x->tp;
                     x->tp->size = getSize(bt_int);
@@ -3102,10 +3102,10 @@ bool callConstructor(TYPE** tp, EXPRESSION** exp, FUNCTIONCALL* params, bool che
 bool callConstructorParam(TYPE** tp, EXPRESSION** exp, TYPE* paramTP, EXPRESSION* paramExp, bool top, bool maybeConversion,
                              bool implicit, bool pointer)
 {
-    FUNCTIONCALL* params = (FUNCTIONCALL*)(FUNCTIONCALL *)Alloc(sizeof(FUNCTIONCALL));
+    FUNCTIONCALL* params = (FUNCTIONCALL*)Alloc(sizeof(FUNCTIONCALL));
     if (paramTP && paramExp)
     {
-        params->arguments = (INITLIST*)(INITLIST *)Alloc(sizeof(INITLIST));
+        params->arguments = (INITLIST*)Alloc(sizeof(INITLIST));
         params->arguments->tp = paramTP;
         params->arguments->exp = paramExp;
     }

--- a/src/occ/parse/declcpp.cpp
+++ b/src/occ/parse/declcpp.cpp
@@ -23,6 +23,7 @@
  */
 
 #include "compiler.h"
+#include "crc32.hpp"
 #include <map>
 extern ARCH_ASM* chosenAssembler;
 extern NAMESPACEVALUES *globalNameSpace, *localNameSpace;
@@ -1291,8 +1292,8 @@ LEXEME* baseClasses(LEXEME* lex, SYMBOL* funcsp, SYMBOL* declsym, enum e_ac defa
                                     src = lst;
                                     while (src && dest)
                                     {
-                                        *workingListPtr = (TEMPLATEPARAMLIST*)(TEMPLATEPARAMLIST *)Alloc(sizeof(TEMPLATEPARAMLIST));
-                                        (*workingListPtr)->p = (TEMPLATEPARAM*)(TEMPLATEPARAM *)Alloc(sizeof(TEMPLATEPARAM));
+                                        *workingListPtr = (TEMPLATEPARAMLIST*)Alloc(sizeof(TEMPLATEPARAMLIST));
+                                        (*workingListPtr)->p = (TEMPLATEPARAM*)Alloc(sizeof(TEMPLATEPARAM));
                                         if (src->p->packed)
                                         {
                                             TEMPLATEPARAMLIST* p = src->p->byPack.pack;
@@ -2022,7 +2023,7 @@ MEMBERINITIALIZERS* expandPackedBaseClasses(SYMBOL* cls, SYMBOL* funcsp, MEMBERI
                         getMemberInitializers(lex, funcsp, &shim, MATCHKW(lex, openpa) ? closepa : end, false);
                         while (shim.arguments)
                         {
-                            *xinit = (INITIALIZER*)(INITIALIZER *)Alloc(sizeof(INITIALIZER));
+                            *xinit = (INITIALIZER*)Alloc(sizeof(INITIALIZER));
                             (*xinit)->basetp = shim.arguments->tp;
                             (*xinit)->exp = shim.arguments->exp;
                             xinit = &(*xinit)->next;
@@ -2138,7 +2139,7 @@ void expandPackedMemberInitializers(SYMBOL* cls, SYMBOL* funcsp, TEMPLATEPARAMLI
                     SetAlternateLex(NULL);
                     while (shim.arguments)
                     {
-                        *xinit = (INITIALIZER*)(INITIALIZER *)Alloc(sizeof(INITIALIZER));
+                        *xinit = (INITIALIZER*)Alloc(sizeof(INITIALIZER));
                         (*xinit)->basetp = shim.arguments->tp;
                         (*xinit)->exp = shim.arguments->exp;
                         xinit = &(*xinit)->next;
@@ -2688,7 +2689,7 @@ LEXEME* insertNamespace(LEXEME* lex, enum e_lk linkage, enum e_sc storage_class,
                                 return lex;
                             }
                         }
-                        tp = (TYPE*)(TYPE *)Alloc(sizeof(TYPE));
+                        tp = (TYPE*)Alloc(sizeof(TYPE));
                         tp->type = bt_void;
                         sp = makeID(sc_namespacealias, tp, NULL, litlate(buf));
                         if (nameSpaceList)
@@ -2754,7 +2755,7 @@ LEXEME* insertNamespace(LEXEME* lex, enum e_lk linkage, enum e_sc storage_class,
     hr = LookupName(buf, globalNameSpace->syms);
     if (!hr)
     {
-        TYPE* tp = (TYPE*)(TYPE *)Alloc(sizeof(TYPE));
+        TYPE* tp = (TYPE*)Alloc(sizeof(TYPE));
         tp->type = bt_void;
         sp = makeID(sc_namespace, tp, NULL, litlate(buf));
         sp->nameSpaceValues = (NAMESPACEVALUES *)Alloc(sizeof(NAMESPACEVALUES));
@@ -2941,7 +2942,7 @@ LEXEME* insertUsing(LEXEME* lex, SYMBOL** sp_out, enum e_ac access, enum e_sc st
                 sp = makeID(sc_typedef, tp, NULL, litlate(idsym->value.s.a));
                 if (inTemplate)
                 {
-                    TYPE* tp1 = (TYPE*)(TYPE *)Alloc(sizeof(TYPE));
+                    TYPE* tp1 = (TYPE*)Alloc(sizeof(TYPE));
                     tp1->type = bt_typedef;
                     tp1->btp = tp;
                     tp1->sp = sp;
@@ -3664,7 +3665,7 @@ LEXEME* getDeclType(LEXEME* lex, SYMBOL* funcsp, TYPE** tn)
         }
         if (extended)
             needkw(&lex, closepa);
-        (*tn) = (TYPE*)(TYPE *)Alloc(sizeof(TYPE));
+        (*tn) = (TYPE*)Alloc(sizeof(TYPE));
         (*tn)->type = bt_auto;
         (*tn)->decltypeauto = true;
         (*tn)->decltypeautoextended = extended;
@@ -3680,7 +3681,7 @@ LEXEME* getDeclType(LEXEME* lex, SYMBOL* funcsp, TYPE** tn)
             exp->v.func->sp = (SYMBOL*)hr->p;
             if (hasAmpersand)
             {
-                (*tn) = (TYPE*)(TYPE *)Alloc(sizeof(TYPE));
+                (*tn) = (TYPE*)Alloc(sizeof(TYPE));
                 if (ismember(exp->v.func->sp))
                 {
                     (*tn)->type = bt_memberptr;

--- a/src/occ/parse/expr.cpp
+++ b/src/occ/parse/expr.cpp
@@ -128,7 +128,7 @@ void thunkForImportTable(EXPRESSION** exp)
             newThunk->mainsym = sp;  // mainsym is the symbol this was derived from
             newThunk->linkage = lk_virtual;
             newThunk->importThunk = true;
-            search = (LIST*)(LIST *)Alloc(sizeof(LIST));
+            search = (LIST*)Alloc(sizeof(LIST));
             search->next = importThunks;
             search->data = newThunk;
             importThunks = search;
@@ -278,7 +278,7 @@ void ValidateMSILFuncPtr(TYPE* dest, TYPE* src, EXPRESSION** exp)
             {
                 int n = 0;
                 HASHREC* hr;
-                FUNCTIONCALL* functionCall = (FUNCTIONCALL*)(FUNCTIONCALL *)Alloc(sizeof(FUNCTIONCALL));
+                FUNCTIONCALL* functionCall = (FUNCTIONCALL*)Alloc(sizeof(FUNCTIONCALL));
                 TYPE* tp1 = src;
                 if (ispointer(tp1))
                     tp1 = basetype(tp1)->btp;
@@ -296,10 +296,10 @@ void ValidateMSILFuncPtr(TYPE* dest, TYPE* src, EXPRESSION** exp)
                 functionCall->sp = sp;
                 functionCall->functp = sp->tp;
                 functionCall->fcall = varNode(en_pc, sp);
-                functionCall->arguments = (INITLIST*)(INITLIST *)Alloc(sizeof(INITLIST));
+                functionCall->arguments = (INITLIST*)Alloc(sizeof(INITLIST));
                 functionCall->arguments->tp = &stdpointer;
                 functionCall->arguments->exp = *exp;
-                functionCall->arguments->next = (INITLIST*)(INITLIST *)Alloc(sizeof(INITLIST));
+                functionCall->arguments->next = (INITLIST*)Alloc(sizeof(INITLIST));
                 functionCall->arguments->next->tp = &stdpointer;
                 functionCall->arguments->next->exp = GetManagedFuncData(tp1);
                 functionCall->ascall = true;
@@ -316,12 +316,12 @@ void ValidateMSILFuncPtr(TYPE* dest, TYPE* src, EXPRESSION** exp)
             sp = gsearch("__OCCMSIL_GetProcThunkToUnmanaged");
             if (sp)
             {
-                FUNCTIONCALL* functionCall = (FUNCTIONCALL*)(FUNCTIONCALL *)Alloc(sizeof(FUNCTIONCALL));
+                FUNCTIONCALL* functionCall = (FUNCTIONCALL*)Alloc(sizeof(FUNCTIONCALL));
                 sp = (SYMBOL*)basetype(sp->tp)->syms->table[0]->p;
                 functionCall->sp = sp;
                 functionCall->functp = sp->tp;
                 functionCall->fcall = varNode(en_pc, sp);
-                functionCall->arguments = (INITLIST*)(INITLIST *)Alloc(sizeof(INITLIST));
+                functionCall->arguments = (INITLIST*)Alloc(sizeof(INITLIST));
                 functionCall->arguments->tp = &stdpointer;
                 functionCall->arguments->exp = *exp;
                 functionCall->ascall = true;
@@ -1116,8 +1116,7 @@ static LEXEME* expression_member(LEXEME* lex, SYMBOL* funcsp, TYPE** tp, EXPRESS
             if (isstructured(*tp))
             {
                 TYPE* x = basetype(*tp);
-                int i;
-                for (i = 0; i < n; i++)
+                for (int i = 0; i < n; i++)
                     if (nesting[i] == x)
                     {
                         break;
@@ -1990,7 +1989,7 @@ void checkArgs(FUNCTIONCALL* params, SYMBOL* funcsp)
                 else if (list->tp->vla)
                 {
                     // cast to a regular pointer if there is no declared param
-                    TYPE* tpx = (TYPE*)(TYPE *)Alloc(sizeof(TYPE));
+                    TYPE* tpx = (TYPE*)Alloc(sizeof(TYPE));
                     tpx->type = bt_pointer;
                     tpx->size = getSize(bt_pointer);
                     tpx->btp = list->tp;
@@ -4290,8 +4289,7 @@ static LEXEME* expression_atomic_func(LEXEME* lex, SYMBOL* funcsp, TYPE** tp, EX
                 lex = expression_assign(lex, funcsp, NULL, &tp1, &exp1, NULL, flags);
                 if (*tp && tp1)
                 {
-                    ATOMICDATA* d;
-                    d = (ATOMICDATA*)Alloc(sizeof(ATOMICDATA));
+                    ATOMICDATA* d = (ATOMICDATA*)Alloc(sizeof(ATOMICDATA));
                     if (!ispointer(tp1))
                     {
                         error(ERR_DEREF);
@@ -4328,8 +4326,7 @@ static LEXEME* expression_atomic_func(LEXEME* lex, SYMBOL* funcsp, TYPE** tp, EX
         else
         {
             TYPE *tpf = NULL, *tpf1;
-            ATOMICDATA* d;
-            d = (ATOMICDATA*)Alloc(sizeof(ATOMICDATA));
+            ATOMICDATA* d = (ATOMICDATA*)Alloc(sizeof(ATOMICDATA));
             switch (kw)
             {
                 case kw_atomic_flag_test_set:
@@ -7051,7 +7048,7 @@ void GetLogicalDestructors(EXPRESSION* top, EXPRESSION* cur)
             {
                 LIST* listitem;
                 sp->destructed = true;
-                listitem = (LIST*)(LIST *)Alloc(sizeof(LIST));
+                listitem = (LIST*)Alloc(sizeof(LIST));
                 listitem->data = sp->dest->exp;
                 listitem->next = top->destructors;
                 top->destructors = listitem;

--- a/src/occ/parse/exprcpp.cpp
+++ b/src/occ/parse/exprcpp.cpp
@@ -1310,7 +1310,7 @@ bool insertOperatorParams(SYMBOL* funcsp, TYPE** tp, EXPRESSION** exp, FUNCTIONC
         return false;
     }
     // finally make a shell to put all this in and add shims for any builtins we want to try
-    tpx = (TYPE*)(TYPE *)Alloc(sizeof(TYPE));
+    tpx = (TYPE*)Alloc(sizeof(TYPE));
     tpx->type = bt_aggregate;
     tpx->rootType = tpx;
     s3 = makeID(sc_overloads, tpx, NULL, name);
@@ -1427,7 +1427,7 @@ bool insertOperatorFunc(enum ovcl cls, enum e_kw kw, SYMBOL* funcsp, TYPE** tp, 
         return false;
     }
     // finally make a shell to put all this in and add shims for any builtins we want to try
-    tpx = (TYPE*)(TYPE *)Alloc(sizeof(TYPE));
+    tpx = (TYPE*)Alloc(sizeof(TYPE));
     tpx->type = bt_aggregate;
     tpx->rootType = tpx;
     s3 = makeID(sc_overloads, tpx, NULL, name);
@@ -2300,8 +2300,8 @@ void ResolveTemplateVariable(TYPE** ttype, EXPRESSION** texpr, TYPE* rtype, TYPE
                     type = atype;
             else
                 type = rtype;
-            params = (TEMPLATEPARAMLIST*)(TEMPLATEPARAMLIST *)Alloc(sizeof(TEMPLATEPARAMLIST));
-            params->p = (TEMPLATEPARAM*)(TEMPLATEPARAM *)Alloc(sizeof(TEMPLATEPARAM));
+            params = (TEMPLATEPARAMLIST*)Alloc(sizeof(TEMPLATEPARAMLIST));
+            params->p = (TEMPLATEPARAM*)Alloc(sizeof(TEMPLATEPARAM));
 
             params->p->type = kw_typename;
             params->p->byClass.dflt = type;

--- a/src/occ/parse/help.cpp
+++ b/src/occ/parse/help.cpp
@@ -590,7 +590,7 @@ void DeduceAuto(TYPE** pat, TYPE* nt)
             if ((*pat)->decltypeauto)
                 if ((*pat)->decltypeautoextended)
                 {
-                    *pat = (TYPE*)(TYPE *)Alloc(sizeof(TYPE));
+                    *pat = (TYPE*)Alloc(sizeof(TYPE));
                     (*pat)->type = bt_lref;
                     (*pat)->size = getSize(bt_pointer);
                     (*pat)->btp = nt;
@@ -765,7 +765,7 @@ EXPRESSION* anonymousVar(enum e_sc storage_class, TYPE* tp)
 {
     static int anonct = 1;
     char buf[256];
-    SYMBOL* rv = (SYMBOL*)(SYMBOL *)Alloc(sizeof(SYMBOL));
+    SYMBOL* rv = (SYMBOL*)Alloc(sizeof(SYMBOL));
     if (tp->size == 0 && isstructured(tp))
         tp = basetype(tp)->sp->tp;
     rv->storage_class = storage_class;
@@ -1768,7 +1768,7 @@ bool isconstaddress(EXPRESSION* exp)
 }
 SYMBOL* clonesym(SYMBOL* sym)
 {
-    SYMBOL* rv = (SYMBOL*)(SYMBOL *)Alloc(sizeof(SYMBOL));
+    SYMBOL* rv = (SYMBOL*)Alloc(sizeof(SYMBOL));
     *rv = *sym;
     return rv;
 }

--- a/src/occ/parse/init.cpp
+++ b/src/occ/parse/init.cpp
@@ -1986,8 +1986,7 @@ static void free_desc(AGGREGATE_DESCRIPTOR** descin, AGGREGATE_DESCRIPTOR** cach
     if (*descin)
     {
         AGGREGATE_DESCRIPTOR* temp = *descin;
-        int max;
-        max = (*descin)->reloffset + (*descin)->offset;
+        int max = (*descin)->reloffset + (*descin)->offset;
         if (max > (*descin)->max)
             (*descin)->max = max;
         max = (*descin)->max;
@@ -2181,8 +2180,7 @@ static bool atend(AGGREGATE_DESCRIPTOR* desc)
 {
     if (isstructured(desc->tp))
         return !desc->hr;
-    else
-        return desc->tp->size && desc->reloffset >= desc->tp->size;
+    return desc->tp->size && desc->reloffset >= desc->tp->size;
 }
 static void increment_desc(AGGREGATE_DESCRIPTOR** desc, AGGREGATE_DESCRIPTOR** cache)
 {
@@ -2215,17 +2213,20 @@ static void increment_desc(AGGREGATE_DESCRIPTOR** desc, AGGREGATE_DESCRIPTOR** c
                             break;
                         }
                     }
-                    if (((SYMBOL*)((*desc)->hr->p))->storage_class != sc_overloads)
                     {
-                        if (((SYMBOL*)((*desc)->hr->p))->tp->hasbits)
+                        SYMBOL* sym_temp = (SYMBOL*)((*desc)->hr->p);
+                    if (sym_temp->storage_class != sc_overloads)
+                    {
+                        if (sym_temp->tp->hasbits)
                         {
-                            if (!((SYMBOL*)((*desc)->hr->p))->anonymous)
+                            if (!(sym_temp)->anonymous)
                                 break;
                         }
-                        else if (((SYMBOL*)((*desc)->hr->p))->offset + (*desc)->offset != offset)
+                        else if (sym_temp->offset + (*desc)->offset != offset)
                         {
                             break;
                         }
+                    }
                     }
                 }
             if ((*desc)->hr)
@@ -2835,7 +2836,7 @@ static LEXEME* initialize_aggregate_type(LEXEME* lex, SYMBOL* funcsp, SYMBOL* ba
             if (cparams.prm_cplusplus && isstructured(itype) && MATCHKW(lex, openpa))
             {
                 // conversion constructor params
-                FUNCTIONCALL* funcparams = (FUNCTIONCALL*)(FUNCTIONCALL *)Alloc(sizeof(FUNCTIONCALL));
+                FUNCTIONCALL* funcparams = (FUNCTIONCALL*)Alloc(sizeof(FUNCTIONCALL));
                 INITIALIZER* it = NULL;
                 lex = getArgs(lex, funcsp, funcparams, closepa, true, 0);
                 if (funcparams->arguments && funcparams->arguments->next)
@@ -3747,7 +3748,7 @@ void RecalculateVariableTemplateInitializers(INITIALIZER** in, INITIALIZER*** ou
         }
         if ((*in)->basetp == 0)
         {
-            **out = (INITIALIZER*)(INITIALIZER *)Alloc(sizeof(INITIALIZER));
+            **out = (INITIALIZER*)Alloc(sizeof(INITIALIZER));
             ***out = **in;
             (**out)->offset = tp->size;
             *out = &(**out)->next;
@@ -3773,7 +3774,7 @@ void RecalculateVariableTemplateInitializers(INITIALIZER** in, INITIALIZER*** ou
         }
         if ((*in)->basetp == 0)
         {
-            **out = (INITIALIZER*)(INITIALIZER *)Alloc(sizeof(INITIALIZER));
+            **out = (INITIALIZER*)Alloc(sizeof(INITIALIZER));
             ***out = **in;
             (**out)->offset = tp->size;
             *out = &(**out)->next;
@@ -3781,7 +3782,7 @@ void RecalculateVariableTemplateInitializers(INITIALIZER** in, INITIALIZER*** ou
     }
     else
     {
-        **out = (INITIALIZER*)(INITIALIZER *)Alloc(sizeof(INITIALIZER));
+        **out = (INITIALIZER*)Alloc(sizeof(INITIALIZER));
         ***out = **in;
         *in = (*in)->next;
         (**out)->basetp = tp;
@@ -4097,7 +4098,7 @@ LEXEME* initialize(LEXEME* lex, SYMBOL* funcsp, SYMBOL* sp, enum e_sc storage_cl
         }
         else if (!isfunction(tp))
         {
-            TYPE* t = (TYPE*)(TYPE *)Alloc(sizeof(TYPE));
+            TYPE* t = (TYPE*)Alloc(sizeof(TYPE));
             t->btp = tp;
             t->type = bt_const;
             t->size = tp->size;

--- a/src/occ/parse/init.cpp
+++ b/src/occ/parse/init.cpp
@@ -521,7 +521,7 @@ int dumpMemberPtr(SYMBOL* sp, TYPE* membertp, bool make_label)
 {
     int lbl = 0;
 #ifndef PARSER_ONLY
-    int vbase = 0, ofs;
+    int vbase = 0;
     EXPRESSION expx, *exp = &expx;
     if (make_label)
     {
@@ -1816,7 +1816,6 @@ static LEXEME* initialize_reference_type(LEXEME* lex, SYMBOL* funcsp, int offset
     EXPRESSION* exp;
     bool needend = false;
     TYPE* tpi = itype;
-    STRUCTSYM s;
     (void)sc;
     if (MATCHKW(lex, begin))
     {
@@ -2016,7 +2015,6 @@ static void unwrap_desc(AGGREGATE_DESCRIPTOR** descin, AGGREGATE_DESCRIPTOR** ca
                 {
                     if (list->basetp && list->exp)
                     {
-                        SYMBOL* fieldsp;
                         initInsert(dest, list->basetp, list->exp, list->offset + (*descin)->offset + (*descin)->reloffset, false);
                         if (ismember(sym))
                         {
@@ -2421,7 +2419,6 @@ static LEXEME* read_strings(LEXEME* lex, INITIALIZER** next, AGGREGATE_DESCRIPTO
     TYPE* btp = basetype(tp->btp);
     int max = tp->size / btp->size;
     int j;
-    EXPRESSION* expr;
     STRING* string = NULL;
     int index = 0;
     int i;
@@ -2657,7 +2654,6 @@ static LEXEME* initialize_aggregate_type(LEXEME* lex, SYMBOL* funcsp, SYMBOL* ba
             TYPE* ctype = itype;
             INITIALIZER* it = NULL;
             bool maybeConversion = true;
-            bool isconversion;
             bool isList = MATCHKW(lex, begin);
             bool constructed = false;
             exp = baseexp;
@@ -3083,7 +3079,7 @@ static LEXEME* initialize_aggregate_type(LEXEME* lex, SYMBOL* funcsp, SYMBOL* ba
             INITIALIZER* test = *init;
             INITIALIZER* testd = *dest;
             INITIALIZER *first = NULL, **push = &first;
-            int last = 0, i;
+            int last = 0;
             for (; test || last < itype->size;)
             {
                 if ((test && last < test->offset) || (!test && last < itype->size))
@@ -3180,7 +3176,6 @@ static LEXEME* initialize_bit(LEXEME* lex, SYMBOL* funcsp, int offset, enum e_sc
 static LEXEME* initialize_auto(LEXEME* lex, SYMBOL* funcsp, int offset, enum e_sc sc, TYPE* itype, INITIALIZER** init,
                                INITIALIZER** dest, SYMBOL* sp)
 {
-    TYPE* tp;
     EXPRESSION* exp;
     bool needend = false;
     if (MATCHKW(lex, begin))
@@ -3253,7 +3248,7 @@ static LEXEME* initialize_auto(LEXEME* lex, SYMBOL* funcsp, int offset, enum e_s
         if (cparams.prm_cplusplus && isstructured(sp->tp))
         {
 
-            INITIALIZER *dest = NULL, *it;
+            INITIALIZER *dest = NULL;
             EXPRESSION* expl = getThisNode(sp);
             initInsert(init, sp->tp, exp, offset, false);
             if (sp->storage_class != sc_auto && sp->storage_class != sc_parameter && sp->storage_class != sc_member &&

--- a/src/occ/parse/inline.cpp
+++ b/src/occ/parse/inline.cpp
@@ -1,25 +1,25 @@
 /* Software License Agreement
- * 
+ *
  *     Copyright(C) 1994-2019 David Lindauer, (LADSoft)
- * 
+ *
  *     This file is part of the Orange C Compiler package.
- * 
+ *
  *     The Orange C Compiler package is free software: you can redistribute it and/or modify
  *     it under the terms of the GNU General Public License as published by
  *     the Free Software Foundation, either version 3 of the License, or
  *     (at your option) any later version.
- * 
+ *
  *     The Orange C Compiler package is distributed in the hope that it will be useful,
  *     but WITHOUT ANY WARRANTY; without even the implied warranty of
  *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  *     GNU General Public License for more details.
- * 
+ *
  *     You should have received a copy of the GNU General Public License
  *     along with Orange C.  If not, see <http://www.gnu.org/licenses/>.
- * 
+ *
  *     contact information:
  *         email: TouchStone222@runbox.com <David Lindauer>
- * 
+ *
  */
 
 #include "compiler.h"
@@ -71,9 +71,9 @@ static void inInsert(SYMBOL* sp)
 {
     // assumes the symbol isn't already there...
     HASHREC** hr = GetHashLink(didInlines, sp->decoratedName);
-    HASHREC* added = (HASHREC *)Alloc(sizeof(HASHREC));
+    HASHREC* added = (HASHREC*)Alloc(sizeof(HASHREC));
     sp->mainsym = NULL;
-    added->p = (struct sym *)sp;
+    added->p = (struct sym*)sp;
     added->next = *hr;
     *hr = added;
 }
@@ -111,7 +111,8 @@ void dumpInlines(void)
                 SYMBOL* sym = (SYMBOL*)funcList->data;
                 if (((sym->isInline && sym->dumpInlineToFile) || sym->genreffed))
                 {
-                    if ((sym->parentClass && sym->parentClass->dontinstantiate && !sym->templateLevel) || sym->attribs.inheritable.linkage2 == lk_import)
+                    if ((sym->parentClass && sym->parentClass->dontinstantiate && !sym->templateLevel) ||
+                        sym->attribs.inheritable.linkage2 == lk_import)
                     {
                         sym->dontinstantiate = true;
                         InsertExtern(sym);
@@ -186,7 +187,7 @@ void dumpInlines(void)
                     LIST* instants = parentTemplate->instantiations;
                     while (instants)
                     {
-                        if (TemplateInstantiationMatch((SYMBOL *)instants->data, sym->parentClass))
+                        if (TemplateInstantiationMatch((SYMBOL*)instants->data, sym->parentClass))
                         {
                             parentTemplate = (SYMBOL*)instants->data;
                             break;
@@ -325,7 +326,7 @@ SYMBOL* getvc1Thunk(int offset)
     rv = search(name, vc1Thunks);
     if (!rv)
     {
-        rv = (SYMBOL *)Alloc(sizeof(SYMBOL));
+        rv = (SYMBOL*)Alloc(sizeof(SYMBOL));
         rv->name = rv->errname = rv->decoratedName = litlate(name);
         rv->storage_class = sc_static;
         rv->linkage = lk_virtual;
@@ -337,7 +338,7 @@ SYMBOL* getvc1Thunk(int offset)
 }
 void InsertInline(SYMBOL* sp)
 {
-    LIST* temp = (LIST *)Alloc(sizeof(LIST));
+    LIST* temp = (LIST*)Alloc(sizeof(LIST));
     temp->data = sp;
     if (isfunction(sp->tp))
     {
@@ -357,7 +358,7 @@ void InsertInline(SYMBOL* sp)
 void InsertInlineData(SYMBOL* sp)
 {
 
-    LIST* temp = (LIST *)Alloc(sizeof(LIST));
+    LIST* temp = (LIST*)Alloc(sizeof(LIST));
     temp->data = sp;
     if (inlineDataHead)
         inlineDataTail = inlineDataTail->next = temp;
@@ -373,13 +374,13 @@ EXPRESSION* inlineexpr(EXPRESSION* node, bool* fromlval)
      * Used because we have to munge the block_nesting field (value.i) of each
      * sp in an inline function to force allocation of the variables
      */
-    EXPRESSION *temp, *temp1;
+    EXPRESSION *temp;
     FUNCTIONCALL* fp;
     int i;
     (void)fromlval;
     if (node == 0)
         return 0;
-    temp = (EXPRESSION*)(EXPRESSION *)Alloc(sizeof(EXPRESSION));
+    temp = (EXPRESSION*)(EXPRESSION*)Alloc(sizeof(EXPRESSION));
     memcpy(temp, node, sizeof(EXPRESSION));
     switch (temp->type)
     {
@@ -635,13 +636,13 @@ EXPRESSION* inlineexpr(EXPRESSION* node, bool* fromlval)
             {
                 INITLIST* args = fp->arguments;
                 INITLIST** p;
-                temp->v.func = (FUNCTIONCALL *)Alloc(sizeof(FUNCTIONCALL));
+                temp->v.func = (FUNCTIONCALL*)Alloc(sizeof(FUNCTIONCALL));
                 *temp->v.func = *fp;
                 p = &temp->v.func->arguments;
                 *p = NULL;
                 while (args)
                 {
-                    *p = (INITLIST *)Alloc(sizeof(INITLIST));
+                    *p = (INITLIST*)Alloc(sizeof(INITLIST));
                     **p = *args;
                     (*p)->exp = inlineexpr((*p)->exp, nullptr);
                     args = args->next;
@@ -669,7 +670,7 @@ STATEMENT* inlinestmt(STATEMENT* block)
     STATEMENT *out = NULL, **outptr = &out;
     while (block != NULL)
     {
-        *outptr = (STATEMENT*)(STATEMENT *)Alloc(sizeof(STATEMENT));
+        *outptr = (STATEMENT*)(STATEMENT*)Alloc(sizeof(STATEMENT));
         memcpy(*outptr, block, sizeof(STATEMENT));
         (*outptr)->next = NULL;
         switch (block->type)
@@ -708,7 +709,7 @@ STATEMENT* inlinestmt(STATEMENT* block)
             case st_passthrough:
                 if (block->lower)
                     if (chosenAssembler->inlineAsmStmt)
-                        block->lower = (STATEMENT *)(*chosenAssembler->inlineAsmStmt)(block->lower);
+                        block->lower = (STATEMENT*)(*chosenAssembler->inlineAsmStmt)(block->lower);
                 break;
             case st_nop:
                 break;
@@ -1086,7 +1087,7 @@ static void setExp(SYMBOL* sx, EXPRESSION* exp, STATEMENT*** stp)
         deref(sx->tp, &tnode);
         sx->inlineFunc.stmt = (STATEMENT*)tnode;
         tnode = exprNode(en_assign, tnode, exp);
-        **stp = (STATEMENT *)Alloc(sizeof(STATEMENT));
+        **stp = (STATEMENT*)Alloc(sizeof(STATEMENT));
         (**stp)->type = st_expr;
         (**stp)->select = tnode;
         *stp = &(**stp)->next;
@@ -1192,7 +1193,7 @@ EXPRESSION* doinline(FUNCTIONCALL* params, SYMBOL* funcsp)
     if (stmt1)
     {
         // this will kill the ret val but we don't care since we've modified params
-        stmt = (STATEMENT *)Alloc(sizeof(STATEMENT));
+        stmt = (STATEMENT*)Alloc(sizeof(STATEMENT));
         stmt->type = st_block;
         stmt->lower = stmt1;
     }
@@ -1283,17 +1284,16 @@ static bool IsEmptyBlocks(STATEMENT* block)
 }
 bool IsEmptyFunction(FUNCTIONCALL* params, SYMBOL* funcsp)
 {
-    STATEMENT* st;
     if (!isfunction(params->functp))
         return false;
     if (!params->sp->inlineFunc.stmt)
         return false;
-    st = params->sp->inlineFunc.stmt;
+    STATEMENT* st = params->sp->inlineFunc.stmt;
     while (st && st->type == st_expr)
     {
         st = st->next;
     }
     if (!st)
         return true;
-    return true || IsEmptyBlocks(st);
+    return true || IsEmptyBlocks(st);  // always returns true?
 }

--- a/src/occ/parse/lambda.cpp
+++ b/src/occ/parse/lambda.cpp
@@ -1,25 +1,25 @@
 /* Software License Agreement
- * 
+ *
  *     Copyright(C) 1994-2019 David Lindauer, (LADSoft)
- * 
+ *
  *     This file is part of the Orange C Compiler package.
- * 
+ *
  *     The Orange C Compiler package is free software: you can redistribute it and/or modify
  *     it under the terms of the GNU General Public License as published by
  *     the Free Software Foundation, either version 3 of the License, or
  *     (at your option) any later version.
- * 
+ *
  *     The Orange C Compiler package is distributed in the hope that it will be useful,
  *     but WITHOUT ANY WARRANTY; without even the implied warranty of
  *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  *     GNU General Public License for more details.
- * 
+ *
  *     You should have received a copy of the GNU General Public License
  *     along with Orange C.  If not, see <http://www.gnu.org/licenses/>.
- * 
+ *
  *     contact information:
  *         email: TouchStone222@runbox.com <David Lindauer>
- * 
+ *
  */
 
 #include "compiler.h"
@@ -62,7 +62,7 @@ extern char infile[];
 extern INCLUDES* includes;
 extern int templateNestingCount;
 extern int dontRegisterTemplate;
-extern SYMBOL *theCurrentFunc;
+extern SYMBOL* theCurrentFunc;
 
 LAMBDA* lambdas;
 
@@ -120,7 +120,7 @@ static TYPE* lambda_type(TYPE* tp, enum e_cm mode)
         {
             tp = tp->btp;
         }
-        tp1 = (TYPE *)Alloc(sizeof(TYPE));
+        tp1 = (TYPE*)Alloc(sizeof(TYPE));
         tp1->type = bt_lref;
         tp1->size = getSize(bt_pointer);
         tp1->btp = tp;
@@ -138,7 +138,7 @@ static TYPE* lambda_type(TYPE* tp, enum e_cm mode)
         tp = basetype(tp);
         if (!lambdas->isMutable)
         {
-            tp1 = (TYPE *)Alloc(sizeof(TYPE));
+            tp1 = (TYPE*)Alloc(sizeof(TYPE));
             tp1->type = bt_const;
             tp1->size = tp->size;
             tp1->btp = tp;
@@ -268,7 +268,7 @@ SYMBOL* lambda_capture(SYMBOL* sym, enum e_cm mode, bool isExplicit)
                     {
                         // we are replicating captures through intermediate lambdas
                         // to make it easier to handle inner lambda creation.
-                        LAMBDASP* ins = (LAMBDASP *)Alloc(sizeof(LAMBDASP));
+                        LAMBDASP* ins = (LAMBDASP*)Alloc(sizeof(LAMBDASP));
                         ins->name = sym->name;
                         ins->parent = sym;
                         sym = clonesym(sym);
@@ -301,7 +301,7 @@ static TYPE* cloneFuncType(SYMBOL* funcin)
     tp = &func->tp;
     while (tp_in)
     {
-        *tp = (TYPE *)Alloc(sizeof(TYPE));
+        *tp = (TYPE*)Alloc(sizeof(TYPE));
         **tp = *(tp_in);
         tp_in = tp_in->btp;
         tp = &(*tp)->btp;
@@ -312,8 +312,8 @@ static TYPE* cloneFuncType(SYMBOL* funcin)
     src = basetype(funcin->tp)->syms->table[0];
     while (src)
     {
-        *dest = (HASHREC *)Alloc(sizeof(HASHREC));
-        (*dest)->p = (struct sym *)clonesym((SYMBOL*)src->p);
+        *dest = (HASHREC*)Alloc(sizeof(HASHREC));
+        (*dest)->p = (struct sym*)clonesym((SYMBOL*)src->p);
         dest = &(*dest)->next;
         src = src->next;
     }
@@ -324,8 +324,8 @@ static void cloneTemplateParams(SYMBOL* func)
     TEMPLATEPARAMLIST** tplp = &func->templateParams;
     HASHREC* hr = basetype(func->tp)->syms->table[0];
     int index = 0;
-    (*tplp) = (TEMPLATEPARAMLIST*)(TEMPLATEPARAM *)Alloc(sizeof(TEMPLATEPARAM));
-    (*tplp)->p = (TEMPLATEPARAM *)Alloc(sizeof(TEMPLATEPARAM));
+    (*tplp) = (TEMPLATEPARAMLIST*)(TEMPLATEPARAM*)Alloc(sizeof(TEMPLATEPARAM));
+    (*tplp)->p = (TEMPLATEPARAM*)Alloc(sizeof(TEMPLATEPARAM));
     (*tplp)->p->type = kw_new;
     tplp = &(*tplp)->next;
     while (hr)
@@ -333,12 +333,12 @@ static void cloneTemplateParams(SYMBOL* func)
         SYMBOL* arg = (SYMBOL*)(hr->p);
         if (!arg->thisPtr)
         {
-            TYPE* tpn = (TYPE*)(TYPE *)Alloc(sizeof(TYPE));
+            TYPE* tpn = (TYPE*)(TYPE*)Alloc(sizeof(TYPE));
             *tpn = *arg->tp;
             arg->tp = tpn;
             UpdateRootTypes(tpn);
-            (*tplp) = (TEMPLATEPARAMLIST*)(TEMPLATEPARAM *)Alloc(sizeof(TEMPLATEPARAM));
-            (*tplp)->p = (TEMPLATEPARAM *)Alloc(sizeof(TEMPLATEPARAM));
+            (*tplp) = (TEMPLATEPARAMLIST*)(TEMPLATEPARAM*)Alloc(sizeof(TEMPLATEPARAM));
+            (*tplp)->p = (TEMPLATEPARAM*)Alloc(sizeof(TEMPLATEPARAM));
             (*tplp)->argsym = arg;
             (*tplp)->p->type = kw_typename;
             arg->tp->templateParam = *tplp;
@@ -352,8 +352,8 @@ static void convertCallToTemplate(SYMBOL* func)
 {
     TEMPLATEPARAMLIST** tplholder;
     HASHREC* hr;
-    func->templateParams = (TEMPLATEPARAMLIST*)(TEMPLATEPARAMLIST *)Alloc(sizeof(TEMPLATEPARAMLIST));
-    func->templateParams->p = (TEMPLATEPARAM *)Alloc(sizeof(TEMPLATEPARAM));
+    func->templateParams = (TEMPLATEPARAMLIST*)(TEMPLATEPARAMLIST*)Alloc(sizeof(TEMPLATEPARAMLIST));
+    func->templateParams->p = (TEMPLATEPARAM*)Alloc(sizeof(TEMPLATEPARAM));
     func->templateParams->p->type = kw_new;
     if (isautotype(lambdas->functp))
         basetype(func->tp)->btp = &stdauto;  // convert return type back to auto
@@ -365,10 +365,10 @@ static void convertCallToTemplate(SYMBOL* func)
         SYMBOL* arg = (SYMBOL*)hr->p;
         if (isautotype(arg->tp))
         {
-            (*tplholder) = (TEMPLATEPARAMLIST*)(TEMPLATEPARAM *)Alloc(sizeof(TEMPLATEPARAM));
-            (*tplholder)->p = (TEMPLATEPARAM *)Alloc(sizeof(TEMPLATEPARAM));
+            (*tplholder) = (TEMPLATEPARAMLIST*)(TEMPLATEPARAM*)Alloc(sizeof(TEMPLATEPARAM));
+            (*tplholder)->p = (TEMPLATEPARAM*)Alloc(sizeof(TEMPLATEPARAM));
             (*tplholder)->argsym = arg;
-            arg->tp = (TYPE*)(TYPE *)Alloc(sizeof(TYPE));
+            arg->tp = (TYPE*)(TYPE*)Alloc(sizeof(TYPE));
             arg->tp->type = bt_templateparam;
             arg->tp->templateParam = *tplholder;
             (*tplholder)->p->type = kw_typename;
@@ -384,7 +384,7 @@ static SYMBOL* createPtrToCaller(SYMBOL* self)
 {
     INITLIST** argptr;
     HASHREC* hr;
-    FUNCTIONCALL* params = (FUNCTIONCALL *)Alloc(sizeof(FUNCTIONCALL));
+    FUNCTIONCALL* params = (FUNCTIONCALL*)Alloc(sizeof(FUNCTIONCALL));
     TYPE* args = cloneFuncType(lambdas->func);
     SYMBOL* func = makeID(sc_static, args, NULL, "___ptrcall");
     BLOCKDATA block1, block2;
@@ -427,12 +427,12 @@ static SYMBOL* createPtrToCaller(SYMBOL* self)
             break;
         sym = clonesym(sym);
         sym->offset -= getSize(bt_pointer);
-        *argptr = (INITLIST *)Alloc(sizeof(INITLIST));
+        *argptr = (INITLIST*)Alloc(sizeof(INITLIST));
         if (isstructured(sym->tp) && !isref(sym->tp))
         {
             SYMBOL* sym2 = anonymousVar(sc_auto, sym->tp)->v.sp;
             sym2->stackblock = true;
-            (*argptr)->exp = varNode(en_auto, sym2); // DAL MODIFIED
+            (*argptr)->exp = varNode(en_auto, sym2);  // DAL MODIFIED
         }
         else
         {
@@ -487,7 +487,7 @@ static SYMBOL* createPtrToCaller(SYMBOL* self)
         }
         strcpy(buf + l - 1, ");} ;");
         includes->handle = NULL;
-        includes->lptr = (unsigned char *)buf;
+        includes->lptr = (unsigned char*)buf;
         lex1 = getsym();
         getDeferredData(lex1, func, true);
         includes->handle = handle;
@@ -506,14 +506,13 @@ static void createConverter(SYMBOL* self)
 {
     SYMBOL* caller = createPtrToCaller(self);
     TYPE* args = cloneFuncType(lambdas->func);
-    SYMBOL* func = makeID(sc_member, (TYPE *)Alloc(sizeof(TYPE)), NULL, overloadNameTab[CI_CAST]);
+    SYMBOL* func = makeID(sc_member, (TYPE*)Alloc(sizeof(TYPE)), NULL, overloadNameTab[CI_CAST]);
     BLOCKDATA block1, block2;
     STATEMENT* st;
-    EXPRESSION* exp;
     SYMBOL* sym = makeID(sc_parameter, &stdvoid, NULL, AnonymousName());
-    HASHREC* hr = (HASHREC *)Alloc(sizeof(HASHREC));
+    HASHREC* hr = (HASHREC*)Alloc(sizeof(HASHREC));
     func->tp->type = bt_func;
-    func->tp->btp = (TYPE *)Alloc(sizeof(TYPE));
+    func->tp->btp = (TYPE*)Alloc(sizeof(TYPE));
     func->tp->btp->type = bt_pointer;
     func->tp->btp->size = getSize(bt_pointer);
     func->tp->btp->btp = args;
@@ -526,7 +525,7 @@ static void createConverter(SYMBOL* self)
     func->storage_class = sc_member;
     func->castoperator = true;
     func->tp->syms = CreateHashTable(1);
-    hr->p = (SYMBOL *)sym;
+    hr->p = (SYMBOL*)sym;
     func->tp->syms->table[0] = hr;
     injectThisPtr(func, func->tp->syms);
     func->parentClass = lambdas->cls;
@@ -557,14 +556,13 @@ static void createConverter(SYMBOL* self)
         int line = includes->line;
         char buf[1000];
         int l = 0;
-        TEMPLATEPARAMLIST *tpl, **tplp, **tplp2;
-        FUNCTIONCALL* f = (FUNCTIONCALL*)(FUNCTIONCALL *)Alloc(sizeof(FUNCTIONCALL));
+        FUNCTIONCALL* f = (FUNCTIONCALL*)(FUNCTIONCALL*)Alloc(sizeof(FUNCTIONCALL));
         INITLIST** args = &f->arguments;
         HASHREC* hr;
         func->templateParams = caller->templateParams;
         func->templateLevel = templateNestingCount;
         func->parentTemplate = func;
-        basetype(func->tp)->btp = (TYPE *)Alloc(sizeof(TYPE));
+        basetype(func->tp)->btp = (TYPE*)Alloc(sizeof(TYPE));
         basetype(func->tp)->btp->type = bt_templatedecltype;
         basetype(func->tp)->btp->templateDeclType = exprNode(en_func, NULL, NULL);
         basetype(func->tp)->btp->templateDeclType->v.func = f;
@@ -579,7 +577,7 @@ static void createConverter(SYMBOL* self)
             }
             else
             {
-                (*args) = (INITLIST*)(INITLIST *)Alloc(sizeof(INITLIST));
+                (*args) = (INITLIST*)(INITLIST*)Alloc(sizeof(INITLIST));
                 (*args)->tp = sym->tp;
                 (*args)->exp = intNode(en_c_i, 0);
                 args = &(*args)->next;
@@ -599,7 +597,7 @@ static void createConverter(SYMBOL* self)
         strcpy(buf + l, "{ ___self=this;return &___ptrcall;} ;");
 
         includes->handle = NULL;
-        includes->lptr = (unsigned char *)buf;
+        includes->lptr = (unsigned char*)buf;
         lex1 = getsym();
         getDeferredData(lex1, func, true);
         includes->handle = handle;
@@ -628,9 +626,8 @@ static bool lambda_get_template_state(SYMBOL* func)
 }
 static void finishClass(void)
 {
-    TYPE* tps = (TYPE*)(TYPE *)Alloc(sizeof(TYPE));
+    TYPE* tps = (TYPE*)(TYPE*)Alloc(sizeof(TYPE));
     SYMBOL* self = makeID(sc_static, tps, NULL, "___self");
-    HASHREC* lst;
     tps->type = bt_pointer;
     tps->size = getSize(bt_pointer);
     tps->btp = lambdas->cls->tp;
@@ -664,13 +661,13 @@ static void finishClass(void)
     if (!lambdas->isMutable)
     {
         SYMBOL* ths = (SYMBOL*)lambdas->func->tp->syms->table[0]->p;
-        TYPE* tp2 = (TYPE *)Alloc(sizeof(TYPE));
+        TYPE* tp2 = (TYPE*)Alloc(sizeof(TYPE));
         tp2->type = bt_const;
         tp2->size = lambdas->func->tp->size;
         tp2->btp = lambdas->func->tp;
         tp2->rootType = lambdas->func->tp->rootType;
         lambdas->func->tp = tp2;
-        tp2 = (TYPE *)Alloc(sizeof(TYPE));
+        tp2 = (TYPE*)Alloc(sizeof(TYPE));
         tp2->type = bt_const;
         tp2->size = basetype(ths->tp)->btp->size;
         tp2->btp = basetype(ths->tp)->btp;
@@ -839,15 +836,14 @@ LEXEME* expression_lambda(LEXEME* lex, SYMBOL* funcsp, TYPE* atp, TYPE** tp, EXP
 {
 
     LAMBDA* self;
-    SYMBOL *vpl, *ths;
-    HASHREC* hrl;
+    SYMBOL* ths;
     TYPE* ltp;
     STRUCTSYM ssl;
     if (funcsp)
         funcsp->noinline = true;
     IncGlobalFlag();
-    self = (LAMBDA *) Alloc(sizeof(LAMBDA));
-    ltp = (TYPE *)Alloc(sizeof(TYPE));
+    self = (LAMBDA*)Alloc(sizeof(LAMBDA));
+    ltp = (TYPE*)Alloc(sizeof(TYPE));
     ltp->type = bt_struct;
     ltp->syms = CreateHashTable(1);
     ltp->tags = CreateHashTable(1);
@@ -1102,7 +1098,7 @@ LEXEME* expression_lambda(LEXEME* lex, SYMBOL* funcsp, TYPE* atp, TYPE** tp, EXP
     }
     else
     {
-        TYPE* tp1 = (TYPE *)Alloc(sizeof(TYPE));
+        TYPE* tp1 = (TYPE*)Alloc(sizeof(TYPE));
         SYMBOL* spi;
         tp1->type = bt_func;
         tp1->size = getSize(bt_pointer);
@@ -1112,7 +1108,7 @@ LEXEME* expression_lambda(LEXEME* lex, SYMBOL* funcsp, TYPE* atp, TYPE** tp, EXP
         self->func->tp = tp1;
         spi = makeID(sc_parameter, tp1, NULL, AnonymousName());
         spi->anonymous = true;
-        spi->tp = (TYPE *)Alloc(sizeof(TYPE));
+        spi->tp = (TYPE*)Alloc(sizeof(TYPE));
         spi->tp->type = bt_void;
         spi->tp->rootType = spi->tp;
         insert(spi, localNameSpace->syms);

--- a/src/occ/parse/lex.cpp
+++ b/src/occ/parse/lex.cpp
@@ -661,7 +661,6 @@ SLCHAR* getString(unsigned char** source, enum e_lexType* tp)
                     if (st[0] == '"')
                     {
                         SLCHAR* rv;
-                        int i;
                         *source = p;
                         IncGlobalFlag();
                         rv = (SLCHAR*)Alloc(sizeof(SLCHAR));
@@ -1175,7 +1174,6 @@ e_lexType getNumber(unsigned char** ptr, unsigned char** end, unsigned char* suf
         }
         if (Utils::iequal((char*)suffix, "F"))
         {
-            float f;
             lastst = l_f;
             CastToFloat(ISZ_FLOAT, rval);
             suffix[0] = 0;
@@ -1198,7 +1196,6 @@ e_lexType getNumber(unsigned char** ptr, unsigned char** end, unsigned char* suf
         }
         else
         {
-            double d;
             lastst = l_d;
             CastToFloat(ISZ_DOUBLE, rval);
         }

--- a/src/occ/parse/libcxx.cpp
+++ b/src/occ/parse/libcxx.cpp
@@ -53,7 +53,6 @@ static struct _ihash
 {
     const char* name;
     INTRINS_FUNC* func;
-
 } defaults[] = {
     {"__is_abstract", is_abstract},
     {"__is_base_of", is_base_of},
@@ -76,9 +75,8 @@ static struct _ihash
 };
 void libcxx_init(void)
 {
-    int i;
     intrinsicHash = CreateHashTable(32);
-    for (i = 0; i < sizeof(defaults) / sizeof(defaults[0]); i++)
+    for (int i = 0; i < sizeof(defaults) / sizeof(defaults[0]); i++)
         AddName((SYMBOL*)&defaults[i], intrinsicHash);
 }
 bool parseBuiltInTypelistFunc(LEXEME** lex, SYMBOL* funcsp, SYMBOL* sym, TYPE** tp, EXPRESSION** exp)
@@ -475,8 +473,7 @@ static bool nothrowConstructible(TYPE* tp)
 static bool is_abstract(LEXEME** lex, SYMBOL* funcsp, SYMBOL* sym, TYPE** tp, EXPRESSION** exp)
 {
     bool rv = false;
-    FUNCTIONCALL funcparams;
-    memset(&funcparams, 0, sizeof(funcparams));
+    FUNCTIONCALL funcparams{};
     funcparams.sp = sym;
     *lex = getTypeList(*lex, funcsp, &funcparams.arguments);
     if (funcparams.arguments && !funcparams.arguments->next)
@@ -492,8 +489,7 @@ static bool is_base_of(LEXEME** lex, SYMBOL* funcsp, SYMBOL* sym, TYPE** tp, EXP
 {
     INITLIST* lst;
     bool rv = false;
-    FUNCTIONCALL funcparams;
-    memset(&funcparams, 0, sizeof(funcparams));
+    FUNCTIONCALL funcparams{};
     funcparams.sp = sym;
     *lex = getTypeList(*lex, funcsp, &funcparams.arguments);
     lst = funcparams.arguments;
@@ -514,8 +510,7 @@ static bool is_base_of(LEXEME** lex, SYMBOL* funcsp, SYMBOL* sym, TYPE** tp, EXP
 static bool is_class(LEXEME** lex, SYMBOL* funcsp, SYMBOL* sym, TYPE** tp, EXPRESSION** exp)
 {
     bool rv = false;
-    FUNCTIONCALL funcparams;
-    memset(&funcparams, 0, sizeof(funcparams));
+    FUNCTIONCALL funcparams{};
     funcparams.sp = sym;
     *lex = getTypeList(*lex, funcsp, &funcparams.arguments);
     if (funcparams.arguments && !funcparams.arguments->next)
@@ -530,8 +525,7 @@ static bool is_constructible(LEXEME** lex, SYMBOL* funcsp, SYMBOL* sym, TYPE** t
 {
     INITLIST* lst;
     bool rv = false;
-    FUNCTIONCALL funcparams;
-    memset(&funcparams, 0, sizeof(funcparams));
+    FUNCTIONCALL funcparams{};
     funcparams.sp = sym;
     *lex = getTypeList(*lex, funcsp, &funcparams.arguments);
     lst = funcparams.arguments;
@@ -598,7 +592,7 @@ static bool is_constructible(LEXEME** lex, SYMBOL* funcsp, SYMBOL* sym, TYPE** t
                         hr = basetype(basetype(tp2)->btp)->syms->table[0];
                         while (hr)
                         {
-                            *arg = (INITLIST*)(INITLIST *)Alloc(sizeof(INITLIST));
+                            *arg = (INITLIST*)Alloc(sizeof(INITLIST));
                             (*arg)->tp = ((SYMBOL*)hr->p)->tp;
                             (*arg)->exp = intNode(en_c_i, 0);
                             arg = &(*arg)->next;
@@ -677,8 +671,7 @@ static bool is_constructible(LEXEME** lex, SYMBOL* funcsp, SYMBOL* sym, TYPE** t
 static bool is_convertible_to(LEXEME** lex, SYMBOL* funcsp, SYMBOL* sym, TYPE** tp, EXPRESSION** exp)
 {
     bool rv = true;
-    FUNCTIONCALL funcparams;
-    memset(&funcparams, 0, sizeof(funcparams));
+    FUNCTIONCALL funcparams{};
     funcparams.sp = sym;
     *lex = getTypeList(*lex, funcsp, &funcparams.arguments);
     if (funcparams.arguments && funcparams.arguments->next && !funcparams.arguments->next->next)
@@ -754,8 +747,7 @@ static bool is_empty(LEXEME** lex, SYMBOL* funcsp, SYMBOL* sym, TYPE** tp, EXPRE
 {
     INITLIST* lst;
     bool rv = false;
-    FUNCTIONCALL funcparams;
-    memset(&funcparams, 0, sizeof(funcparams));
+    FUNCTIONCALL funcparams{};
     funcparams.sp = sym;
     *lex = getTypeList(*lex, funcsp, &funcparams.arguments);
     lst = funcparams.arguments;
@@ -776,8 +768,7 @@ static bool is_empty(LEXEME** lex, SYMBOL* funcsp, SYMBOL* sym, TYPE** tp, EXPRE
 static bool is_enum(LEXEME** lex, SYMBOL* funcsp, SYMBOL* sym, TYPE** tp, EXPRESSION** exp)
 {
     bool rv = false;
-    FUNCTIONCALL funcparams;
-    memset(&funcparams, 0, sizeof(funcparams));
+    FUNCTIONCALL funcparams{};
     funcparams.sp = sym;
     *lex = getTypeList(*lex, funcsp, &funcparams.arguments);
     if (funcparams.arguments && !funcparams.arguments->next)
@@ -791,8 +782,7 @@ static bool is_enum(LEXEME** lex, SYMBOL* funcsp, SYMBOL* sym, TYPE** tp, EXPRES
 static bool is_final(LEXEME** lex, SYMBOL* funcsp, SYMBOL* sym, TYPE** tp, EXPRESSION** exp)
 {
     bool rv = false;
-    FUNCTIONCALL funcparams;
-    memset(&funcparams, 0, sizeof(funcparams));
+    FUNCTIONCALL funcparams{};
     funcparams.sp = sym;
     *lex = getTypeList(*lex, funcsp, &funcparams.arguments);
     if (funcparams.arguments && !funcparams.arguments->next)
@@ -807,8 +797,8 @@ static bool is_final(LEXEME** lex, SYMBOL* funcsp, SYMBOL* sym, TYPE** tp, EXPRE
 static bool is_literal(LEXEME** lex, SYMBOL* funcsp, SYMBOL* sym, TYPE** tp, EXPRESSION** exp)
 {
     bool rv = false;
-    FUNCTIONCALL funcparams;
-    memset(&funcparams, 0, sizeof(funcparams));
+    FUNCTIONCALL funcparams{};
+
     funcparams.sp = sym;
     *lex = getTypeList(*lex, funcsp, &funcparams.arguments);
     if (funcparams.arguments && !funcparams.arguments->next)
@@ -824,8 +814,7 @@ static bool is_nothrow_constructible(LEXEME** lex, SYMBOL* funcsp, SYMBOL* sym, 
 {
     INITLIST* lst;
     bool rv = false;
-    FUNCTIONCALL funcparams;
-    memset(&funcparams, 0, sizeof(funcparams));
+    FUNCTIONCALL funcparams{};
     funcparams.sp = sym;
     *lex = getTypeList(*lex, funcsp, &funcparams.arguments);
     lst = funcparams.arguments;
@@ -850,8 +839,7 @@ static bool is_pod(LEXEME** lex, SYMBOL* funcsp, SYMBOL* sym, TYPE** tp, EXPRESS
 {
     INITLIST* lst;
     bool rv = false;
-    FUNCTIONCALL funcparams;
-    memset(&funcparams, 0, sizeof(funcparams));
+    FUNCTIONCALL funcparams{};
     funcparams.sp = sym;
     *lex = getTypeList(*lex, funcsp, &funcparams.arguments);
     lst = funcparams.arguments;
@@ -872,8 +860,7 @@ static bool is_polymorphic(LEXEME** lex, SYMBOL* funcsp, SYMBOL* sym, TYPE** tp,
 {
     INITLIST* lst;
     bool rv = false;
-    FUNCTIONCALL funcparams;
-    memset(&funcparams, 0, sizeof(funcparams));
+    FUNCTIONCALL funcparams{};
     funcparams.sp = sym;
     *lex = getTypeList(*lex, funcsp, &funcparams.arguments);
     lst = funcparams.arguments;
@@ -896,8 +883,8 @@ static bool is_standard_layout(LEXEME** lex, SYMBOL* funcsp, SYMBOL* sym, TYPE**
 {
     INITLIST* lst;
     bool rv = false;
-    FUNCTIONCALL funcparams;
-    memset(&funcparams, 0, sizeof(funcparams));
+    FUNCTIONCALL funcparams{};
+
     funcparams.sp = sym;
     *lex = getTypeList(*lex, funcsp, &funcparams.arguments);
     lst = funcparams.arguments;
@@ -918,8 +905,7 @@ static bool is_trivial(LEXEME** lex, SYMBOL* funcsp, SYMBOL* sym, TYPE** tp, EXP
 {
     INITLIST* lst;
     bool rv = false;
-    FUNCTIONCALL funcparams;
-    memset(&funcparams, 0, sizeof(funcparams));
+    FUNCTIONCALL funcparams{};
     funcparams.sp = sym;
     *lex = getTypeList(*lex, funcsp, &funcparams.arguments);
     lst = funcparams.arguments;
@@ -940,8 +926,7 @@ static bool is_trivially_assignable(LEXEME** lex, SYMBOL* funcsp, SYMBOL* sym, T
 {
     INITLIST* lst;
     bool rv = false;
-    FUNCTIONCALL funcparams;
-    memset(&funcparams, 0, sizeof(funcparams));
+    FUNCTIONCALL funcparams{};
     funcparams.sp = sym;
     *lex = getTypeList(*lex, funcsp, &funcparams.arguments);
     lst = funcparams.arguments;
@@ -963,8 +948,7 @@ static bool is_trivially_constructible(LEXEME** lex, SYMBOL* funcsp, SYMBOL* sym
 {
     INITLIST* lst;
     bool rv = false;
-    FUNCTIONCALL funcparams;
-    memset(&funcparams, 0, sizeof(funcparams));
+    FUNCTIONCALL funcparams{};
     funcparams.sp = sym;
     *lex = getTypeList(*lex, funcsp, &funcparams.arguments);
     lst = funcparams.arguments;
@@ -985,8 +969,7 @@ static bool is_trivially_copyable(LEXEME** lex, SYMBOL* funcsp, SYMBOL* sym, TYP
 {
     INITLIST* lst;
     bool rv = false;
-    FUNCTIONCALL funcparams;
-    memset(&funcparams, 0, sizeof(funcparams));
+    FUNCTIONCALL funcparams{};
     funcparams.sp = sym;
     *lex = getTypeList(*lex, funcsp, &funcparams.arguments);
     lst = funcparams.arguments;
@@ -1007,8 +990,7 @@ static bool is_trivially_copyable(LEXEME** lex, SYMBOL* funcsp, SYMBOL* sym, TYP
 static bool is_union(LEXEME** lex, SYMBOL* funcsp, SYMBOL* sym, TYPE** tp, EXPRESSION** exp)
 {
     bool rv = false;
-    FUNCTIONCALL funcparams;
-    memset(&funcparams, 0, sizeof(funcparams));
+    FUNCTIONCALL funcparams{};
     funcparams.sp = sym;
     *lex = getTypeList(*lex, funcsp, &funcparams.arguments);
     if (funcparams.arguments && !funcparams.arguments->next)

--- a/src/occ/parse/libcxx.cpp
+++ b/src/occ/parse/libcxx.cpp
@@ -175,7 +175,7 @@ static bool isStandardLayout(TYPE* tp, SYMBOL** result)
     {
         int n;
         int access = -1;
-        SYMBOL *found = NULL, *first;
+        SYMBOL *found = NULL;
         HASHREC* hr;
         n = FindBaseClassWithData(tp->sp, &found);
         if (n > 1)
@@ -474,7 +474,6 @@ static bool nothrowConstructible(TYPE* tp)
 }
 static bool is_abstract(LEXEME** lex, SYMBOL* funcsp, SYMBOL* sym, TYPE** tp, EXPRESSION** exp)
 {
-    INITLIST* lst;
     bool rv = false;
     FUNCTIONCALL funcparams;
     memset(&funcparams, 0, sizeof(funcparams));
@@ -514,7 +513,6 @@ static bool is_base_of(LEXEME** lex, SYMBOL* funcsp, SYMBOL* sym, TYPE** tp, EXP
 }
 static bool is_class(LEXEME** lex, SYMBOL* funcsp, SYMBOL* sym, TYPE** tp, EXPRESSION** exp)
 {
-    INITLIST* lst;
     bool rv = false;
     FUNCTIONCALL funcparams;
     memset(&funcparams, 0, sizeof(funcparams));
@@ -777,7 +775,6 @@ static bool is_empty(LEXEME** lex, SYMBOL* funcsp, SYMBOL* sym, TYPE** tp, EXPRE
 }
 static bool is_enum(LEXEME** lex, SYMBOL* funcsp, SYMBOL* sym, TYPE** tp, EXPRESSION** exp)
 {
-    INITLIST* lst;
     bool rv = false;
     FUNCTIONCALL funcparams;
     memset(&funcparams, 0, sizeof(funcparams));
@@ -793,7 +790,6 @@ static bool is_enum(LEXEME** lex, SYMBOL* funcsp, SYMBOL* sym, TYPE** tp, EXPRES
 }
 static bool is_final(LEXEME** lex, SYMBOL* funcsp, SYMBOL* sym, TYPE** tp, EXPRESSION** exp)
 {
-    INITLIST* lst;
     bool rv = false;
     FUNCTIONCALL funcparams;
     memset(&funcparams, 0, sizeof(funcparams));
@@ -810,7 +806,6 @@ static bool is_final(LEXEME** lex, SYMBOL* funcsp, SYMBOL* sym, TYPE** tp, EXPRE
 }
 static bool is_literal(LEXEME** lex, SYMBOL* funcsp, SYMBOL* sym, TYPE** tp, EXPRESSION** exp)
 {
-    INITLIST* lst;
     bool rv = false;
     FUNCTIONCALL funcparams;
     memset(&funcparams, 0, sizeof(funcparams));
@@ -1011,7 +1006,6 @@ static bool is_trivially_copyable(LEXEME** lex, SYMBOL* funcsp, SYMBOL* sym, TYP
 }
 static bool is_union(LEXEME** lex, SYMBOL* funcsp, SYMBOL* sym, TYPE** tp, EXPRESSION** exp)
 {
-    INITLIST* lst;
     bool rv = false;
     FUNCTIONCALL funcparams;
     memset(&funcparams, 0, sizeof(funcparams));

--- a/src/occ/parse/list.cpp
+++ b/src/occ/parse/list.cpp
@@ -320,7 +320,6 @@ void list_var(SYMBOL* sp, int i)
 /* won't do child namespaces */
 void list_table(HASHTABLE* t, int j)
 {
-    SYMBOL* sp;
     int i;
     if (!cparams.prm_listfile)
         return;

--- a/src/occ/parse/mangle.cpp
+++ b/src/occ/parse/mangle.cpp
@@ -595,7 +595,6 @@ static char* getName(char* in, SYMBOL* sp)
     }
     else
     {
-        int i;
         char buf[4096], *p;
         p = mangleClasses(buf, sp->parentClass);
         if (p != buf)
@@ -617,7 +616,6 @@ static char* getName(char* in, SYMBOL* sp)
 char* mangleType(char* in, TYPE* tp, bool first)
 {
     char nm[4096];
-    int i;
     HASHREC* hr;
     if (!tp)
     {
@@ -950,7 +948,7 @@ void SetLinkerNames(SYMBOL* sym, enum e_lk linkage)
             p = mangleNameSpaces(p, lastParent->parentNameSpace);
             p = mangleClasses(p, sym->parentClass);
             *p++ = '@';
-            if (sym->templateLevel && sym->templateParams && sym->templateParams)
+            if (sym->templateLevel && sym->templateParams)
             {
                 p = mangleTemplate(p, sym, sym->templateParams);
             }

--- a/src/occ/parse/osutil.cpp
+++ b/src/occ/parse/osutil.cpp
@@ -79,6 +79,8 @@ int showVersion = false;
 struct DefValue {
     std::string name;
     bool undef;
+    DefValue() = default;
+    DefValue(char* val, bool bval) : undef(bval), name(val) {}
 };
 std::deque<DefValue> defines;
 
@@ -646,12 +648,12 @@ void def_setup(char select, char* string)
  * activation for command line #defines
  */
 {
-    defines.push_back(DefValue{ string, 0 });
+    defines.emplace_back(string, false);
 }
 
 void undef_setup(char select, char* string)
 {
-    defines.push_back(DefValue{ string, 1 });
+    defines.emplace_back(string, true);
 }
 
 /*-------------------------------------------------------------------------*/
@@ -728,7 +730,7 @@ void setglbdefs(void)
         }
     }
 #endif
-    for (auto d : defines)
+    for (auto& d : defines)
     {
         size_t n = d.name.find_first_of("=");
         std::string name, val;

--- a/src/occ/parse/osutil.cpp
+++ b/src/occ/parse/osutil.cpp
@@ -85,6 +85,7 @@ std::deque<DefValue> defines;
 static bool has_output_file;
 static char** set_searchpath = &prm_searchpath;
 static char** set_libpath = &prm_libpath;
+[[noreturn]]
 void fatal(const char* fmt, ...)
 {
     va_list argptr;
@@ -1106,8 +1107,6 @@ void internalError(int a)
 void ccinit(int argc, char* argv[])
 {
     char buffer[260];
-    char* p;
-    int rv;
     int i;
 
     strcpy(copyright, COPYRIGHT);

--- a/src/occ/parse/property.cpp
+++ b/src/occ/parse/property.cpp
@@ -42,7 +42,7 @@ static SYMBOL* CreateSetterPrototype(SYMBOL* sp)
     value = makeID(sc_parameter, sp->tp, nullptr, "value");
     value->attribs.inheritable.used = true;  // to avoid unused variable errors
     rv->access = ac_public;
-    rv->tp = (TYPE*)(TYPE *)Alloc(sizeof(TYPE));
+    rv->tp = (TYPE*)Alloc(sizeof(TYPE));
     rv->tp->sp = rv;
     rv->tp->type = bt_func;
     rv->tp->btp = &stdvoid;
@@ -60,7 +60,7 @@ static SYMBOL* CreateGetterPrototype(SYMBOL* sp)
     rv = makeID(sp->storage_class, nullptr, nullptr, litlate(name));
     nullparam = makeID(sc_parameter, &stdvoid, nullptr, "__void");
     rv->access = ac_public;
-    rv->tp = (TYPE*)(TYPE *)Alloc(sizeof(TYPE));
+    rv->tp = (TYPE*)Alloc(sizeof(TYPE));
     rv->tp->sp = rv;
     rv->tp->type = bt_func;
     rv->tp->btp = sp->tp;
@@ -79,7 +79,7 @@ static void insertfunc(SYMBOL* in, HASHTABLE* syms)
         funcs = (SYMBOL*)((*hr)->p);
     if (!funcs)
     {
-        TYPE* tp = (TYPE*)(TYPE *)Alloc(sizeof(TYPE));
+        TYPE* tp = (TYPE*)Alloc(sizeof(TYPE));
         tp->type = bt_aggregate;
         tp->rootType = tp;
         funcs = makeID(sc_overloads, tp, 0, litlate(in->name));

--- a/src/occ/parse/stmt.cpp
+++ b/src/occ/parse/stmt.cpp
@@ -2474,7 +2474,7 @@ static LEXEME* asm_declare(LEXEME* lex)
             }
             lex = getsym();
         }
-    } while (lex && MATCHKW(lex, comma));
+    } while (MATCHKW(lex, comma));
     return lex;
 }
 LEXEME* statement_catch(LEXEME* lex, SYMBOL* funcsp, BLOCKDATA* parent, int label, int startlab, int endlab)
@@ -2605,7 +2605,7 @@ LEXEME* statement_asm(LEXEME* lex, SYMBOL* funcsp, BLOCKDATA* parent)
         else
         {
             currentLineData(parent, lex, 0);
-            while (cparams.prm_assemble && lex && MATCHKW(lex, semicolon))
+            while (cparams.prm_assemble && MATCHKW(lex, semicolon))
                 lex = SkipToNextLine();
             if (lex)
             {

--- a/src/occ/parse/template.cpp
+++ b/src/occ/parse/template.cpp
@@ -5535,7 +5535,9 @@ void TemplatePartialOrdering(SYMBOL** table, int count, FUNCTIONCALL* funcparams
                             {
                                 params->p->byNonType.temp = (EXPRESSION *)exprchk->data;
                                 exprchk = exprchk->next;
-                                
+                                
+
+
 
 
 
@@ -5834,7 +5836,9 @@ static void TemplateTransferClassDeferred(SYMBOL* newCls, SYMBOL* tmpl)
                                             tpo = tpo->next;
                                             tpn = tpn->next;
                                         }
-                                        
+                                        
+
+
 
 
 
@@ -8018,7 +8022,6 @@ static TEMPLATEPARAMLIST* SpecifyPackedInt(TEMPLATEPARAMLIST* arg, TEMPLATEPARAM
     return arg;
 }
 static bool SpecifyAllTemplateArgs_unused(SYMBOL* sym, TEMPLATEPARAMLIST* args, TEMPLATEPARAMLIST* orig)
-
 {
     TEMPLATEPARAMLIST* spl = sym->templateParams->next;
     while (args)

--- a/src/occ/parse86/makefile
+++ b/src/occ/parse86/makefile
@@ -29,7 +29,6 @@ CPP_DEPENDENCIES= \
     $(BACKEND_FILES) \
     ccmain.cpp \
     ccif.cpp \
-    crc32.cpp \
     db.cpp \
     piper.cpp \
     beinterf.cpp \

--- a/src/occ/parse86/occpr.vcxproj
+++ b/src/occ/parse86/occpr.vcxproj
@@ -164,7 +164,6 @@
     <ClCompile Include="..\parse\constopt.cpp" />
     <ClCompile Include="..\parse\cppbltin.cpp" />
     <ClCompile Include="..\parse\cpplookup.cpp" />
-    <ClCompile Include="..\parse\crc32.cpp" />
     <ClCompile Include="..\parse\debug.cpp" />
     <ClCompile Include="..\parse\declare.cpp" />
     <ClCompile Include="..\parse\declcons.cpp" />
@@ -209,6 +208,7 @@
     <ClInclude Include="..\preproc\pp.h" />
     <ClInclude Include="db.h" />
     <ClInclude Include="parser.h" />
+    <ClInclude Include="..\parse\crc32.hpp" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\ocpp\ocpp.vcxproj">

--- a/src/occ/parse86/occpr.vcxproj
+++ b/src/occ/parse86/occpr.vcxproj
@@ -90,6 +90,7 @@
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
       <DebugInformationFormat>EditAndContinue</DebugInformationFormat>
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
+      <ConformanceMode>true</ConformanceMode>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>

--- a/src/occ/parse86/occpr.vcxproj.filters
+++ b/src/occ/parse86/occpr.vcxproj.filters
@@ -129,14 +129,14 @@
     <ClCompile Include="..\parse\wseh.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
-    <ClCompile Include="..\parse\crc32.cpp">
-      <Filter>Source Files</Filter>
-    </ClCompile>
     <ClCompile Include="..\..\sqlite3\sqlite3.c">
       <Filter>Source Files</Filter>
     </ClCompile>
   </ItemGroup>
   <ItemGroup>
+    <ClInclude Include="..\parse\crc32.hpp">
+      <Filter>Header Files</Filter>
+    </ClInclude>
     <ClInclude Include="..\parse\beinterf.h">
       <Filter>Header Files</Filter>
     </ClInclude>

--- a/src/occ/preproc/occp.vcxproj
+++ b/src/occ/preproc/occp.vcxproj
@@ -89,6 +89,7 @@
       <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;CPREPROCESSOR;_CRT_SECURE_NO_WARNINGS;USE_LONGLONG;BORLAND;MICROSOFT;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>..\parse;..\middle;..\..\ocpp</AdditionalIncludeDirectories>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
+      <ConformanceMode>true</ConformanceMode>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>

--- a/src/occ/preproc/osutil.cpp
+++ b/src/occ/preproc/osutil.cpp
@@ -67,6 +67,8 @@ LIST* clist = 0;
 struct DefValue {
     std::string name;
     bool undef;
+    DefValue() = default;
+    DefValue(char* val, bool bval) : undef(bval), name(val) {}
 };
 std::deque<DefValue> defines;
 
@@ -541,12 +543,12 @@ void def_setup(char select, char* string)
 * activation for command line #defines
 */
 {
-    defines.push_back(DefValue{ string, 0 });
+    defines.emplace_back(string, false);
 }
 
 void undef_setup(char select, char* string)
 {
-    defines.push_back(DefValue{ string, 1 });
+    defines.emplace_back(string, true);
 }
 
 /*-------------------------------------------------------------------------*/
@@ -607,7 +609,7 @@ void setglbdefs(void)
         }
     }
 #endif
-    for (auto d : defines)
+    for (auto& d : defines)
     {
         size_t n = d.name.find_first_of("=");
         std::string name, val;

--- a/src/occ/preproc/preproc.cpp
+++ b/src/occ/preproc/preproc.cpp
@@ -32,6 +32,8 @@
 extern "C" char* getcwd(char*, int);
 #endif
 
+#include <crc32.hpp>
+
 #ifdef PARSER_ONLY
 size_t ccReadFile(void* __ptr, size_t __size, size_t __n, FILE* __stream);
 void ccSetFileLine(char* filename, int lineno);
@@ -102,14 +104,8 @@ struct inmac
     const char* s;
     void (*func)(char*);
 } ingrownmacros[INGROWNMACROS] = {{"__FILE__", filemac},
-                                  {
-                                      "__DATE__",
-                                      datemac,
-                                  },
-                                  {
-                                      "__DATEISO__",
-                                      dateisomac,
-                                  },
+                                  {"__DATE__",datemac},
+                                  {"__DATEISO__",dateisomac},
                                   {"__TIME__", timemac},
                                   {"__LINE__", linemac},
                                   {"__COUNTER__", countermac}};
@@ -722,7 +718,6 @@ unsigned char* getauxname(unsigned char* ptr, char** bufp)
 unsigned onceCRC(FILE* handle)
 {
     unsigned crc = 0;
-    unsigned PartialCRC32(unsigned crc, unsigned char* data, size_t len);
 #    ifdef PARSER_ONLY
     crc = PartialCRC32(crc, (unsigned char *)includes->handle, includes->filesize);
 #    else
@@ -933,7 +928,7 @@ void dopragma(bool fromPragma)
                 return;
             IncGlobalFlag();
             f = litlate(buf);
-            l = (LIST*)(LIST *)Alloc(sizeof(LIST));
+            l = (LIST*)Alloc(sizeof(LIST));
             l->data = f;
             l->next = libincludes;
             libincludes = l;
@@ -1232,7 +1227,7 @@ void doinclude(void)
     inc->fname = litlate(name);
     if (nonSys)
     {
-        LIST* fil = (LIST*)(LIST *)Alloc(sizeof(LIST));
+        LIST* fil = (LIST*)Alloc(sizeof(LIST));
         fil->data = inc->fname;
         fil->next = nonSysIncludeFiles;
         nonSysIncludeFiles = fil;
@@ -2226,8 +2221,7 @@ static void repdefines(unsigned char* lptr)
 void pushif(void)
 /* Push an if context */
 {
-    IFSTRUCT* p;
-    p = (IFSTRUCT*)globalAlloc(sizeof(IFSTRUCT));
+    IFSTRUCT* p = (IFSTRUCT*)globalAlloc(sizeof(IFSTRUCT));
     p->next = includes->ifs;
     p->iflevel = includes->ifskip;
     p->elsetaken = includes->elsetaken;

--- a/src/occ/x86/InstructionParser.cpp
+++ b/src/occ/x86/InstructionParser.cpp
@@ -1,25 +1,25 @@
 /* Software License Agreement
- * 
+ *
  *     Copyright(C) 1994-2019 David Lindauer, (LADSoft)
- * 
+ *
  *     This file is part of the Orange C Compiler package.
- * 
+ *
  *     The Orange C Compiler package is free software: you can redistribute it and/or modify
  *     it under the terms of the GNU General Public License as published by
  *     the Free Software Foundation, either version 3 of the License, or
  *     (at your option) any later version.
- * 
+ *
  *     The Orange C Compiler package is distributed in the hope that it will be useful,
  *     but WITHOUT ANY WARRANTY; without even the implied warranty of
  *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  *     GNU General Public License for more details.
- * 
+ *
  *     You should have received a copy of the GNU General Public License
  *     along with Orange C.  If not, see <http://www.gnu.org/licenses/>.
- * 
+ *
  *     contact information:
  *         email: TouchStone222@runbox.com <David Lindauer>
- * 
+ *
  */
 
 #include "InstructionParser.h"
@@ -134,7 +134,7 @@ bool InstructionParser::SetNumber(int tokenPos, int oldVal, int newVal)
 }
 bool InstructionParser::MatchesOpcode(std::string opcode)
 {
-    return opcodeTable.end() != opcodeTable.find(opcode) || prefixTable.end() != prefixTable.find(opcode);
+    return opcodeTable.find(opcode) != opcodeTable.end() || prefixTable.find(opcode) != prefixTable.end();
 }
 
 std::string InstructionParser::FormatInstruction(ocode* ins)

--- a/src/occ/x86/dbgtypes.cpp
+++ b/src/occ/x86/dbgtypes.cpp
@@ -78,8 +78,8 @@ bool dbgtypes::typecompare::operator()(const TYPE* left, const TYPE* right) cons
                             }
                             else if (left->syms && right->syms && left->syms->table && right->syms->table)
                             {
-                                const HASHREC* hr1 = left->syms->table[0];
-                                const HASHREC* hr2 = right->syms->table[0];
+                                HASHREC* hr1 = left->syms->table[0];
+                                HASHREC* hr2 = right->syms->table[0];
                                 while (hr1 && hr2)
                                 {
                                     SYMBOL* sym1 = (SYMBOL*)hr1->p;

--- a/src/occ/x86/gen.cpp
+++ b/src/occ/x86/gen.cpp
@@ -81,7 +81,7 @@ AMODE* make_label(int lab)
 {
     EXPRESSION* lnode;
     AMODE* ap;
-    lnode = (EXPRESSION*)(EXPRESSION *)beLocalAlloc(sizeof(EXPRESSION));
+    lnode = (EXPRESSION*)(EXPRESSION*)beLocalAlloc(sizeof(EXPRESSION));
     lnode->type = en_labcon;
     lnode->v.i = lab;
     ap = (AMODE*)beLocalAlloc(sizeof(AMODE));
@@ -231,7 +231,7 @@ AMODE* aimmed(ULLONG_TYPE i)
     AMODE* ap;
     EXPRESSION* ep;
     i &= 0xffffffffU;
-    ep = (EXPRESSION*)(EXPRESSION *)beLocalAlloc(sizeof(EXPRESSION));
+    ep = (EXPRESSION*)beLocalAlloc(sizeof(EXPRESSION));
     ep->type = en_c_i;
     ep->v.i = i;
     ap = (AMODE*)beLocalAlloc(sizeof(AMODE));
@@ -313,7 +313,7 @@ AMODE* make_offset(EXPRESSION* node)
 AMODE* make_stack(int number)
 {
     AMODE* ap = (AMODE*)beLocalAlloc(sizeof(AMODE));
-    EXPRESSION* ep = (EXPRESSION*)(EXPRESSION *)beLocalAlloc(sizeof(EXPRESSION));
+    EXPRESSION* ep = (EXPRESSION*)beLocalAlloc(sizeof(EXPRESSION));
     ep->type = en_c_i;
     ep->v.i = -number;
     ap->mode = am_indisp;
@@ -550,23 +550,34 @@ AMODE *floatzero(AMODE *ap)
 }
 
 bool sameTemp(QUAD* head);
+// implement clamp here so that below makes sense
+template<class T>
+constexpr const T& clamp( const T& v, const T& lo, const T& hi )
+{
+    return v < lo ? lo : hi < v ? hi : v;
+}
+template<class T>
+constexpr const T& clamp_hi(const T& v, const T& lo)
+{
+    return clamp(v, lo, v);
+}
 int beRegFromTempInd(QUAD* q, IMODE* im, int which)
 {
     if (which)
     {
-        return (q->scaleColor < 0) ? 0 : q->scaleColor;
+        return clamp_hi(q->scaleColor, 0);
     }
     if (im == q->ans)
     {
-        return (q->ansColor < 0) ? 0 : q->ansColor;
+        return clamp_hi(q->ansColor, 0);
     }
     else if (im == q->dc.left)
     {
-        return (q->leftColor < 0) ? 0 : q->leftColor;
+        return clamp_hi(q->leftColor, 0);
     }
     else
     {
-        return (q->rightColor < 0) ? 0 : q->rightColor;
+        return clamp_hi(q->rightColor, 0);
     }
 }
 int beRegFromTemp(QUAD* q, IMODE* im) { return beRegFromTempInd(q, im, 0); }
@@ -1829,7 +1840,7 @@ static void compactSwitchHeader(LLONG_TYPE bottom)
     }
 
     peep_tail->noopt = true;
-    lnode = (EXPRESSION*)(EXPRESSION *)beLocalAlloc(sizeof(EXPRESSION));
+    lnode = (EXPRESSION*)(EXPRESSION*)beLocalAlloc(sizeof(EXPRESSION));
     lnode->type = en_labcon;
     lnode->v.i = tablab;
     if (bottom)

--- a/src/occ/x86/gen.cpp
+++ b/src/occ/x86/gen.cpp
@@ -5022,7 +5022,6 @@ void asm_functail(QUAD* q, int begin, int size) /* functail start or end */
 }
 void asm_atomic(QUAD* q)
 {
-    bool pushed;
     int needsync = q->dc.opcode != i_xchg ? q->dc.left->offset->v.i : 0; 
     if (needsync < 0)
         needsync = 0;

--- a/src/occ/x86/inasm.cpp
+++ b/src/occ/x86/inasm.cpp
@@ -1,25 +1,25 @@
 /* Software License Agreement
- * 
+ *
  *     Copyright(C) 1994-2019 David Lindauer, (LADSoft)
- * 
+ *
  *     This file is part of the Orange C Compiler package.
- * 
+ *
  *     The Orange C Compiler package is free software: you can redistribute it and/or modify
  *     it under the terms of the GNU General Public License as published by
  *     the Free Software Foundation, either version 3 of the License, or
  *     (at your option) any later version.
- * 
+ *
  *     The Orange C Compiler package is distributed in the hope that it will be useful,
  *     but WITHOUT ANY WARRANTY; without even the implied warranty of
  *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  *     GNU General Public License for more details.
- * 
+ *
  *     You should have received a copy of the GNU General Public License
  *     along with Orange C.  If not, see <http://www.gnu.org/licenses/>.
- * 
+ *
  *     contact information:
  *         email: TouchStone222@runbox.com <David Lindauer>
- * 
+ *
  */
 
 /*
@@ -36,7 +36,7 @@ extern int prm_assembler;
 extern HASHTABLE* labelSyms;
 extern int usingEsp;
 extern InstructionParser* instructionParser;
-extern SYMBOL *theCurrentFunc;
+extern SYMBOL* theCurrentFunc;
 
 bool assembling;
 static ASMREG* regimage;
@@ -60,18 +60,18 @@ static enum e_opcode op;
 #define ERR_BAD_OPERAND_COMBO 11
 #define ERR_INVALID_USE_OF_INSTRUCTION 12
 static const char* errors[] = {"Lable expected",
-                         "Illegal address mode",
-                         "Address mode expected",
-                         "Invalid opcode",
-                         "Invalid instruction size",
-                         "Invalid index mode",
-                         "Invalid scale specifier",
-                         "Use LEA to take address of auto variable",
-                         "Too many segment specifiers",
-                         "Syntax error while parsing instruction",
-                         "Unknown operand",
-                         "Invalid combination of operands",
-                         "Invalid use of instruction"
+                               "Illegal address mode",
+                               "Address mode expected",
+                               "Invalid opcode",
+                               "Invalid instruction size",
+                               "Invalid index mode",
+                               "Invalid scale specifier",
+                               "Use LEA to take address of auto variable",
+                               "Too many segment specifiers",
+                               "Syntax error while parsing instruction",
+                               "Unknown operand",
+                               "Invalid combination of operands",
+                               "Invalid use of instruction"
 
 };
 ASMNAME directiveLst[] = {{"db", op_reserved, ISZ_UCHAR, 0},
@@ -82,37 +82,37 @@ ASMNAME directiveLst[] = {{"db", op_reserved, ISZ_UCHAR, 0},
                           {"label", op_label, 0, 0},
                           {0}};
 ASMREG reglst[] = {{"cs", am_seg, 1, ISZ_USHORT},     {"ds", am_seg, 2, ISZ_USHORT},
-                              {"es", am_seg, 3, ISZ_USHORT},     {"fs", am_seg, 4, ISZ_USHORT},
-                              {"gs", am_seg, 5, ISZ_USHORT},     {"ss", am_seg, 6, ISZ_USHORT},
-                              {"al", am_dreg, 0, ISZ_UCHAR},     {"cl", am_dreg, 1, ISZ_UCHAR},
-                              {"dl", am_dreg, 2, ISZ_UCHAR},     {"bl", am_dreg, 3, ISZ_UCHAR},
-                              {"ah", am_dreg, 4, ISZ_UCHAR},     {"ch", am_dreg, 5, ISZ_UCHAR},
-                              {"dh", am_dreg, 6, ISZ_UCHAR},     {"bh", am_dreg, 7, ISZ_UCHAR},
-                              {"ax", am_dreg, 0, ISZ_USHORT},    {"cx", am_dreg, 1, ISZ_USHORT},
-                              {"dx", am_dreg, 2, ISZ_USHORT},    {"bx", am_dreg, 3, ISZ_USHORT},
-                              {"sp", am_dreg, 4, ISZ_USHORT},    {"bp", am_dreg, 5, ISZ_USHORT},
-                              {"si", am_dreg, 6, ISZ_USHORT},    {"di", am_dreg, 7, ISZ_USHORT},
-                              {"eax", am_dreg, 0, ISZ_UINT},     {"ecx", am_dreg, 1, ISZ_UINT},
-                              {"edx", am_dreg, 2, ISZ_UINT},     {"ebx", am_dreg, 3, ISZ_UINT},
-                              {"esp", am_dreg, 4, ISZ_UINT},     {"ebp", am_dreg, 5, ISZ_UINT},
-                              {"esi", am_dreg, 6, ISZ_UINT},     {"edi", am_dreg, 7, ISZ_UINT},
-                              {"st", am_freg, 0, ISZ_LDOUBLE},   {"cr0", am_screg, 0, ISZ_UINT},
-                              {"cr1", am_screg, 1, ISZ_UINT},    {"cr2", am_screg, 2, ISZ_UINT},
-                              {"cr3", am_screg, 3, ISZ_UINT},    {"cr4", am_screg, 4, ISZ_UINT},
-                              {"cr5", am_screg, 5, ISZ_UINT},    {"cr6", am_screg, 6, ISZ_UINT},
-                              {"cr7", am_screg, 7, ISZ_UINT},    {"dr0", am_sdreg, 0, ISZ_UINT},
-                              {"dr1", am_sdreg, 1, ISZ_UINT},    {"dr2", am_sdreg, 2, ISZ_UINT},
-                              {"dr3", am_sdreg, 3, ISZ_UINT},    {"dr4", am_sdreg, 4, ISZ_UINT},
-                              {"dr5", am_sdreg, 5, ISZ_UINT},    {"dr6", am_sdreg, 6, ISZ_UINT},
-                              {"dr7", am_sdreg, 7, ISZ_UINT},    {"tr0", am_streg, 0, ISZ_UINT},
-                              {"tr1", am_streg, 1, ISZ_UINT},    {"tr2", am_streg, 2, ISZ_UINT},
-                              {"tr3", am_streg, 3, ISZ_UINT},    {"tr4", am_streg, 4, ISZ_UINT},
-                              {"tr5", am_streg, 5, ISZ_UINT},    {"tr6", am_streg, 6, ISZ_UINT},
-                              {"tr7", am_streg, 7, ISZ_UINT},    {"byte", am_ext, akw_byte, 0},
-                              {"word", am_ext, akw_word, 0},     {"dword", am_ext, akw_dword, 0},
-                              {"fword", am_ext, akw_fword, 0},   {"qword", am_ext, akw_qword, 0},
-                              {"tbyte", am_ext, akw_tbyte, 0},   {"ptr", am_ext, akw_ptr, 0},
-                              {"offset", am_ext, akw_offset, 0}, {0, 0, 0}};
+                   {"es", am_seg, 3, ISZ_USHORT},     {"fs", am_seg, 4, ISZ_USHORT},
+                   {"gs", am_seg, 5, ISZ_USHORT},     {"ss", am_seg, 6, ISZ_USHORT},
+                   {"al", am_dreg, 0, ISZ_UCHAR},     {"cl", am_dreg, 1, ISZ_UCHAR},
+                   {"dl", am_dreg, 2, ISZ_UCHAR},     {"bl", am_dreg, 3, ISZ_UCHAR},
+                   {"ah", am_dreg, 4, ISZ_UCHAR},     {"ch", am_dreg, 5, ISZ_UCHAR},
+                   {"dh", am_dreg, 6, ISZ_UCHAR},     {"bh", am_dreg, 7, ISZ_UCHAR},
+                   {"ax", am_dreg, 0, ISZ_USHORT},    {"cx", am_dreg, 1, ISZ_USHORT},
+                   {"dx", am_dreg, 2, ISZ_USHORT},    {"bx", am_dreg, 3, ISZ_USHORT},
+                   {"sp", am_dreg, 4, ISZ_USHORT},    {"bp", am_dreg, 5, ISZ_USHORT},
+                   {"si", am_dreg, 6, ISZ_USHORT},    {"di", am_dreg, 7, ISZ_USHORT},
+                   {"eax", am_dreg, 0, ISZ_UINT},     {"ecx", am_dreg, 1, ISZ_UINT},
+                   {"edx", am_dreg, 2, ISZ_UINT},     {"ebx", am_dreg, 3, ISZ_UINT},
+                   {"esp", am_dreg, 4, ISZ_UINT},     {"ebp", am_dreg, 5, ISZ_UINT},
+                   {"esi", am_dreg, 6, ISZ_UINT},     {"edi", am_dreg, 7, ISZ_UINT},
+                   {"st", am_freg, 0, ISZ_LDOUBLE},   {"cr0", am_screg, 0, ISZ_UINT},
+                   {"cr1", am_screg, 1, ISZ_UINT},    {"cr2", am_screg, 2, ISZ_UINT},
+                   {"cr3", am_screg, 3, ISZ_UINT},    {"cr4", am_screg, 4, ISZ_UINT},
+                   {"cr5", am_screg, 5, ISZ_UINT},    {"cr6", am_screg, 6, ISZ_UINT},
+                   {"cr7", am_screg, 7, ISZ_UINT},    {"dr0", am_sdreg, 0, ISZ_UINT},
+                   {"dr1", am_sdreg, 1, ISZ_UINT},    {"dr2", am_sdreg, 2, ISZ_UINT},
+                   {"dr3", am_sdreg, 3, ISZ_UINT},    {"dr4", am_sdreg, 4, ISZ_UINT},
+                   {"dr5", am_sdreg, 5, ISZ_UINT},    {"dr6", am_sdreg, 6, ISZ_UINT},
+                   {"dr7", am_sdreg, 7, ISZ_UINT},    {"tr0", am_streg, 0, ISZ_UINT},
+                   {"tr1", am_streg, 1, ISZ_UINT},    {"tr2", am_streg, 2, ISZ_UINT},
+                   {"tr3", am_streg, 3, ISZ_UINT},    {"tr4", am_streg, 4, ISZ_UINT},
+                   {"tr5", am_streg, 5, ISZ_UINT},    {"tr6", am_streg, 6, ISZ_UINT},
+                   {"tr7", am_streg, 7, ISZ_UINT},    {"byte", am_ext, akw_byte, 0},
+                   {"word", am_ext, akw_word, 0},     {"dword", am_ext, akw_dword, 0},
+                   {"fword", am_ext, akw_fword, 0},   {"qword", am_ext, akw_qword, 0},
+                   {"tbyte", am_ext, akw_tbyte, 0},   {"ptr", am_ext, akw_ptr, 0},
+                   {"offset", am_ext, akw_offset, 0}, {0, 0, 0}};
 
 typedef struct
 {
@@ -176,7 +176,7 @@ static void inasm_err(int errnum)
 
 static void inasm_txsym(void)
 {
-    if (lex && ISID(lex))
+    if (ISID(lex))
     {
         ASM_HASH_ENTRY* e = (ASM_HASH_ENTRY*)search(lex->value.s.a, asmHash);
         if (e)
@@ -252,7 +252,7 @@ static EXPRESSION* inasm_ident(void)
             sp->realdeclline = lex->realline;
             sp->declfilenum = lex->filenum;
             sp->attribs.inheritable.used = true;
-            sp->tp = (TYPE*)(TYPE *)beLocalAlloc(sizeof(TYPE));
+            sp->tp = (TYPE*)(TYPE*)beLocalAlloc(sizeof(TYPE));
             sp->tp->type = bt_unsigned;
             sp->tp->bits = sp->tp->startbit = -1;
             sp->offset = codeLabel++;
@@ -328,7 +328,7 @@ static EXPRESSION* inasm_label(void)
         sp->declline = sp->origdeclline = lex->line;
         sp->realdeclline = lex->realline;
         sp->declfilenum = lex->filenum;
-        sp->tp = (TYPE*)(TYPE *)beLocalAlloc(sizeof(TYPE));
+        sp->tp = (TYPE*)(TYPE*)beLocalAlloc(sizeof(TYPE));
         sp->tp->type = bt_unsigned;
         sp->tp->bits = sp->tp->startbit = -1;
         sp->offset = codeLabel++;
@@ -967,7 +967,7 @@ enum e_opcode inasm_op(void)
     }
     op = insdata->atype;
     inasm_getsym();
-    floating = op >= op_f2xm1 & op <= op_fyl2xp1;
+    floating = op >= op_f2xm1 && op <= op_fyl2xp1;
     return (e_opcode)op;
 }
 
@@ -1044,7 +1044,7 @@ static int getData(STATEMENT* snp)
             lex = SkipToNextLine();
             break;
         }
-    } while (lex && MATCHKW(lex, comma));
+    } while (MATCHKW(lex, comma));
     return 1;
 }
 bool ateol(void)

--- a/src/occ/x86/inasm.cpp
+++ b/src/occ/x86/inasm.cpp
@@ -967,7 +967,7 @@ enum e_opcode inasm_op(void)
     }
     op = insdata->atype;
     inasm_getsym();
-    floating = op >= op_f2xm1 && op <= op_fyl2xp1;
+    floating = op >= op_f2xm1 & op <= op_fyl2xp1;
     return (e_opcode)op;
 }
 

--- a/src/occ/x86/invoke.cpp
+++ b/src/occ/x86/invoke.cpp
@@ -213,7 +213,6 @@ int RunExternalFiles(char* rootPath)
     char outName[260], *p;
     int rv;
     char temp[260];
-    int i;
     char verbosityString[20];
 
     memset(verbosityString, 0, sizeof(verbosityString));

--- a/src/occ/x86/makefile
+++ b/src/occ/x86/makefile
@@ -31,7 +31,6 @@ C_DEPENDENCIES= \
 CPP_DEPENDENCIES= \
     ccmain.cpp \
     config.cpp \
-    crc32.cpp \
     beinterf.cpp \
     browse.cpp \
     ccerr.cpp \

--- a/src/occ/x86/outasm.cpp
+++ b/src/occ/x86/outasm.cpp
@@ -195,7 +195,6 @@ void oa_putconst(int op, int sz, EXPRESSION* offset, bool doSign)
 {
     char buf[4096];
     SYMBOL* sp;
-    int toffs;
     switch (offset->type)
     {
         int m;
@@ -1419,7 +1418,6 @@ void dump_muldivval(void)
                 bePrintf("\tdd\t0%xh\n", muldivlink->value);
             else
             {
-                char buf[256];
                 UBYTE data[12];
                 int len = 0;
                 int i;

--- a/src/occ/x86/outcode.cpp
+++ b/src/occ/x86/outcode.cpp
@@ -179,7 +179,6 @@ void debug_outputtypedef(SYMBOL* sp) { typedefs.push_back(sp); }
 
 void outcode_file_init(void)
 {
-    int i;
     instructionParser = InstructionParser::GetInstance();
     adjustUsesESP();
     lastIncludeNum = 0;
@@ -201,7 +200,6 @@ void outcode_file_init(void)
 
 void outcode_func_init(void)
 {
-    int i;
 #define NOP 0x90
 }
 

--- a/src/occ/x86/outcode.cpp
+++ b/src/occ/x86/outcode.cpp
@@ -42,17 +42,6 @@
 #include <map>
 #include <set>
 #include <deque>
-#if 0
-#    include <new>
-void * operator new(std::size_t n) throw(std::bad_alloc)
-{
-    return (void *)Alloc(n);
-}
-void operator delete(void * p) throw()
-{
-    // noop
-}
-#endif
 #define FULLVERSION
 
 extern char realOutFile[260];
@@ -550,7 +539,7 @@ void output_obj_file(void)
 
 void compile_start(char* name)
 {
-    LIST* newItem = (LIST*)(LIST *)beGlobalAlloc(sizeof(LIST));
+    LIST* newItem = (LIST*)beGlobalAlloc(sizeof(LIST));
     newItem->data = beGlobalAlloc(strlen(name) + 1);
     strcpy((char*)newItem->data, name);
 
@@ -563,7 +552,7 @@ void include_start(char* name, int num)
 {
     if (num > lastIncludeNum)
     {
-        LIST* newItem = (LIST*)(LIST *)beGlobalAlloc(sizeof(LIST));
+        LIST* newItem = (LIST*)beGlobalAlloc(sizeof(LIST));
         newItem->data = beGlobalAlloc(strlen(name) + 1);
         strcpy((char*)newItem->data, name);
 

--- a/src/occ/x86/rewrite.cpp
+++ b/src/occ/x86/rewrite.cpp
@@ -114,7 +114,7 @@ void precolor(QUAD* head) /* precolor an instruction */
             if (head->dc.left->mode != i_direct || head->dc.left->offset->type != en_tempref)
             {
                 IMODE* temp = InitTempOpt(head->dc.left->size, head->dc.left->size);
-                QUAD* q = (QUAD*)(QUAD *)Alloc(sizeof(QUAD));
+                QUAD* q = (QUAD*)Alloc(sizeof(QUAD));
                 *q = *head;
                 q->dc.opcode = i_assn;
                 q->ans = temp;
@@ -1015,8 +1015,8 @@ int examine_icode(QUAD* head)
                 ians = head->ans;
                 temp = AllocateTemp(ISZ_ADDR);
                 //				tempInfo[tempCount-1] = temp->offset;
-                q = (QUAD*)(QUAD *)beLocalAlloc(sizeof(QUAD));
-                tl = (IMODE*)(IMODE *)beLocalAlloc(sizeof(IMODE));
+                q = (QUAD*)beLocalAlloc(sizeof(QUAD));
+                tl = (IMODE*)beLocalAlloc(sizeof(IMODE));
                 tans = hl = indnode(temp, head->ans->size);
                 *tl = *head->ans;
                 tl->size = ISZ_ADDR;
@@ -1047,8 +1047,8 @@ int examine_icode(QUAD* head)
                 {
                     temp = AllocateTemp(ISZ_ADDR);
                     //				tempInfo[tempCount-1] = temp->offset;
-                    q = (QUAD*)(QUAD *)beLocalAlloc(sizeof(QUAD));
-                    tl = (IMODE*)(IMODE *)beLocalAlloc(sizeof(IMODE));
+                    q = (QUAD*)beLocalAlloc(sizeof(QUAD));
+                    tl = (IMODE*)beLocalAlloc(sizeof(IMODE));
                     hl = indnode(temp, head->dc.left->size);
                     *tl = *head->dc.left;
                     tl->size = ISZ_ADDR;
@@ -1074,8 +1074,8 @@ int examine_icode(QUAD* head)
                 {
                     temp = AllocateTemp(ISZ_ADDR);
                     //				tempInfo[tempCount-1] = temp->offset;
-                    q = (QUAD*)(QUAD *)beLocalAlloc(sizeof(QUAD));
-                    tl = (IMODE*)(IMODE *)beLocalAlloc(sizeof(IMODE));
+                    q = (QUAD*)beLocalAlloc(sizeof(QUAD));
+                    tl = (IMODE*)beLocalAlloc(sizeof(IMODE));
                     hl = indnode(temp, head->dc.right->size);
                     *tl = *head->dc.right;
                     tl->size = ISZ_ADDR;
@@ -1101,7 +1101,7 @@ int examine_icode(QUAD* head)
                 {
                     IMODE* temp;
                     QUAD* q;
-                    q = (QUAD*)(QUAD *)beLocalAlloc(sizeof(QUAD));
+                    q = (QUAD*)beLocalAlloc(sizeof(QUAD));
                     temp = AllocateTemp(head->dc.left->size);
                     q->dc.opcode = i_assn;
                     q->ans = temp;
@@ -1121,7 +1121,7 @@ int examine_icode(QUAD* head)
                 {
                     IMODE* temp;
                     QUAD* q;
-                    q = (QUAD*)(QUAD *)beLocalAlloc(sizeof(QUAD));
+                    q = (QUAD*)beLocalAlloc(sizeof(QUAD));
                     temp = AllocateTemp(head->dc.right->size);
                     q->dc.opcode = i_assn;
                     q->ans = temp;
@@ -1139,7 +1139,7 @@ int examine_icode(QUAD* head)
                 {
                     IMODE* temp;
                     QUAD* q;
-                    q = (QUAD*)(QUAD *)beLocalAlloc(sizeof(QUAD));
+                    q = (QUAD*)beLocalAlloc(sizeof(QUAD));
                     *q = *head;
                     temp = AllocateTemp(head->ans->size);
                     q->ans = temp;
@@ -1266,7 +1266,7 @@ int examine_icode(QUAD* head)
                 }
                 else if (head->dc.left->size >= ISZ_FLOAT && (head->ans->size == ISZ_ULONGLONG || head->ans->size == -ISZ_ULONGLONG))
                 {
-                    QUAD* q = (QUAD*)(QUAD *)beLocalAlloc(sizeof(QUAD));
+                    QUAD* q = (QUAD*)beLocalAlloc(sizeof(QUAD));
                     IMODE *ret;
                     ret = AllocateTemp(head->ans->size);
                     ret->retval = true;
@@ -1290,7 +1290,7 @@ int examine_icode(QUAD* head)
                     }
                     insert_parm(head->back, q);
 
-                    q = (QUAD*)(QUAD *)beLocalAlloc(sizeof(QUAD));
+                    q = (QUAD*)beLocalAlloc(sizeof(QUAD));
                     q->dc.opcode = i_gosub;
                     if (head->ans->size == ISZ_ULONGLONG)
                         q->dc.left = set_symbol("__ftoull", true);
@@ -1315,7 +1315,7 @@ int examine_icode(QUAD* head)
                 }
                 else if (head->dc.left->size >= ISZ_FLOAT && (head->ans->size <= ISZ_ULONG && head->ans->size != ISZ_BOOLEAN))
                 {
-                    QUAD* q = (QUAD*)(QUAD *)beLocalAlloc(sizeof(QUAD));
+                    QUAD* q = (QUAD*)beLocalAlloc(sizeof(QUAD));
                     IMODE *ret;
                     int n = 0;
                     switch (head->ans->size)
@@ -1375,7 +1375,7 @@ int examine_icode(QUAD* head)
                     }
                     insert_parm(head->back, q);
 
-                    q = (QUAD*)(QUAD *)beLocalAlloc(sizeof(QUAD));
+                    q = (QUAD*)beLocalAlloc(sizeof(QUAD));
                     q->dc.opcode = i_gosub;
                     q->dc.left = set_symbol("__ftoi", true);
                     InsertInstruction(head->back, q);
@@ -1398,7 +1398,7 @@ int examine_icode(QUAD* head)
                 else if (head->ans->size >= ISZ_FLOAT && (head->dc.left->size == ISZ_UINT || head->dc.left->size == ISZ_ULONG ||
                     head->dc.left->size == ISZ_ULONGLONG || head->dc.left->size == -ISZ_ULONGLONG))
                 {
-                    QUAD* q = (QUAD*)(QUAD *)beLocalAlloc(sizeof(QUAD));
+                    QUAD* q = (QUAD*)beLocalAlloc(sizeof(QUAD));
                     IMODE *ret;
                     ret = AllocateTemp(ISZ_DOUBLE);
                     ret->retval = true;
@@ -1406,7 +1406,7 @@ int examine_icode(QUAD* head)
                     q->dc.opcode = i_parm;
                     q->dc.left = head->dc.left;
                     insert_parm(head->back, q);
-                    q = (QUAD*)(QUAD *)beLocalAlloc(sizeof(QUAD));
+                    q = (QUAD*)beLocalAlloc(sizeof(QUAD));
                     q->dc.opcode = i_gosub;
                     if (head->dc.left->size == ISZ_ULONGLONG)
                         q->dc.left = set_symbol("__ulltof", true);
@@ -1855,7 +1855,7 @@ int examine_icode(QUAD* head)
                         if (head->dc.right->size >= ISZ_ULONGLONG || head->dc.right->size == -ISZ_ULONGLONG)
                         {
                             temp = AllocateTemp(ISZ_ULONG);
-                            q = (QUAD*)(QUAD *)beLocalAlloc(sizeof(QUAD));
+                            q = (QUAD*)beLocalAlloc(sizeof(QUAD));
                             q->dc.opcode = i_assn;
                             q->ans = temp;
                             q->dc.left = head->dc.right;
@@ -1863,15 +1863,15 @@ int examine_icode(QUAD* head)
                             head->temps |= TEMP_RIGHT;
                             InsertInstruction(head->back, q);
                         }
-                        q = (QUAD*)(QUAD *)beLocalAlloc(sizeof(QUAD));
+                        q = (QUAD*)beLocalAlloc(sizeof(QUAD));
                         q->dc.opcode = i_parm;
                         q->dc.left = head->dc.right;
                         insert_parm(head->back, q);
-                        q = (QUAD*)(QUAD *)beLocalAlloc(sizeof(QUAD));
+                        q = (QUAD*)beLocalAlloc(sizeof(QUAD));
                         q->dc.opcode = i_parm;
                         q->dc.left = head->dc.left;
                         insert_parm(head->back, q);
-                        q = (QUAD*)(QUAD *)beLocalAlloc(sizeof(QUAD));
+                        q = (QUAD*)beLocalAlloc(sizeof(QUAD));
                         q->dc.opcode = i_gosub;
                         switch (head->dc.opcode)
                         {
@@ -2009,7 +2009,7 @@ int examine_icode(QUAD* head)
                         q->temps = TEMP_ANS | (head->temps & TEMP_RIGHT ? TEMP_LEFT : 0);
                         InsertInstruction(head->back, q);
                     }
-                    q = (QUAD*)(QUAD *)beLocalAlloc(sizeof(QUAD));
+                    q = (QUAD*)beLocalAlloc(sizeof(QUAD));
                     q->dc.opcode = i_parm;
                     q->dc.left = head->dc.right;
                     insert_parm(head->back, q);
@@ -2025,11 +2025,11 @@ int examine_icode(QUAD* head)
                         InsertInstruction(head->back, q);
 
                     }
-                    q = (QUAD*)(QUAD *)beLocalAlloc(sizeof(QUAD));
+                    q = (QUAD*)beLocalAlloc(sizeof(QUAD));
                     q->dc.opcode = i_parm;
                     q->dc.left = head->dc.left;
                     insert_parm(head->back, q);
-                    q = (QUAD*)(QUAD *)beLocalAlloc(sizeof(QUAD));
+                    q = (QUAD*)beLocalAlloc(sizeof(QUAD));
                     q->dc.opcode = i_gosub;
                     switch (head->dc.opcode)
                     {
@@ -2085,15 +2085,15 @@ int examine_icode(QUAD* head)
                     IMODE* ret;
                     ret = AllocateTemp(head->ans->size);
                     ret->retval = true;
-                    q = (QUAD*)(QUAD *)beLocalAlloc(sizeof(QUAD));
+                    q = (QUAD*)beLocalAlloc(sizeof(QUAD));
                     q->dc.opcode = i_parm;
                     q->dc.left = head->dc.right;
                     insert_parm(head->back, q);
-                    q = (QUAD*)(QUAD *)beLocalAlloc(sizeof(QUAD));
+                    q = (QUAD*)beLocalAlloc(sizeof(QUAD));
                     q->dc.opcode = i_parm;
                     q->dc.left = head->dc.left;
                     insert_parm(head->back, q);
-                    q = (QUAD*)(QUAD *)beLocalAlloc(sizeof(QUAD));
+                    q = (QUAD*)beLocalAlloc(sizeof(QUAD));
                     q->dc.opcode = i_gosub;
                     switch (head->dc.opcode)
                     {
@@ -2139,7 +2139,7 @@ int examine_icode(QUAD* head)
                     QUAD* q;
                     IMODE* temp;
                     temp = AllocateTemp(head->dc.left->size);
-                    q = (QUAD*)(QUAD *)beLocalAlloc(sizeof(QUAD));
+                    q = (QUAD*)beLocalAlloc(sizeof(QUAD));
                     q->dc.opcode = i_assn;
                     q->dc.left = temp;
                     q->ans = head->ans;

--- a/src/ocl/ocl.vcxproj
+++ b/src/ocl/ocl.vcxproj
@@ -87,6 +87,7 @@
       <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;MICROSOFT;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
+      <ConformanceMode>true</ConformanceMode>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>

--- a/src/ocpp/Floating.h
+++ b/src/ocpp/Floating.h
@@ -146,22 +146,22 @@ class FPF
         type = right.type;
         return *this;
     }
-    FPF& operator=(long long right)
+    FPF& operator=(const long long& right)
     {
         FromLongLong(right);
         return *this;
     }
-    FPF& operator=(unsigned long long right)
+    FPF& operator=(const unsigned long long& right)
     {
         FromUnsignedLongLong(right);
         return *this;
     }
-    FPF& operator=(int right)
+    FPF& operator=(const int& right)
     {
         FromLongLong(right);
         return *this;
     }
-    FPF& operator=(unsigned right)
+    FPF& operator=(const unsigned& right)
     {
         FromUnsignedLongLong(right);
         return *this;
@@ -204,10 +204,10 @@ class FPF
     void Init();
 
   private:
-    int exp; /* Signed exponent...no bias */
-    u16 mantissa[INTERNAL_FPF_PRECISION];
-    u8 type; /* Indicates, NORMAL, SUBNORMAL, etc. */
-    u8 sign; /* Mantissa sign */
+    int exp = 0; /* Signed exponent...no bias */
+    u16 mantissa[INTERNAL_FPF_PRECISION] = {0};
+    u8 type = 0; /* Indicates, NORMAL, SUBNORMAL, etc. */
+    u8 sign = 0; /* Mantissa sign */
     static bool bigEndian;
     static FPF tensTab[10];
     static bool initted;

--- a/src/ocpp/InputFile.cpp
+++ b/src/ocpp/InputFile.cpp
@@ -50,7 +50,7 @@ bool InputFile::GetLine(std::string& line)
     line = std::string(buf);
     return true;
 }
-std::string InputFile::GetErrorName(bool full, std::string& name)
+std::string InputFile::GetErrorName(bool full, const std::string& name)
 {
     if (full)
     {

--- a/src/ocpp/InputFile.h
+++ b/src/ocpp/InputFile.h
@@ -71,14 +71,14 @@ class InputFile
     std::string GetErrorFile() { return errname; }
     void CheckErrors();
     virtual bool GetLine(std::string& line);
-    void SetErrlineInfo(std::string& name, int line)
+    void SetErrlineInfo(const std::string& name, int line)
     {
         errname = name;
         lineno = line;
     }
 
   protected:
-    std::string GetErrorName(bool full, std::string& name);
+    std::string GetErrorName(bool full, const std::string& name);
     virtual int StripComment(char* line) { return strlen(line); }
     bool ReadLine(char* line);
     void CheckUTF8BOM();

--- a/src/ocpp/PreProcessor.cpp
+++ b/src/ocpp/PreProcessor.cpp
@@ -188,7 +188,7 @@ bool PreProcessor::GetLine(std::string& line)
                         if (trigraphs)
                             line = StripDigraphs(line);
                         Tokenizer tk(line.substr(n + 1), &hash);
-                        const Token* t = tk.Next();
+                        std::shared_ptr<Token> t = tk.Next();
                         if (t->IsKeyword())
                         {
                             if (t->GetKeyword() == ASSIGN || t->GetKeyword() == IASSIGN)

--- a/src/ocpp/Token.h
+++ b/src/ocpp/Token.h
@@ -60,7 +60,7 @@ class Token
     virtual std::wstring GetRawString() const { return L""; }
     virtual long long GetInteger() const { return 0; }
     virtual Type GetNumericType() const { return t_int; }
-    virtual const FPF* GetFloat() const { return 0; }
+    virtual FPF GetFloat() const { return FPF(); }
     virtual int GetKeyword() const { return -1; }
     virtual const std::string& GetId() const
     {
@@ -94,7 +94,6 @@ class StringToken : public Token
 
   private:
     bool wide;
-    bool doParse;
     std::wstring str;
     std::wstring raw;
 };
@@ -124,7 +123,7 @@ class NumericToken : public Token
     virtual bool IsNumeric() const { return true; }
     virtual bool IsFloating() const { return parsedAsFloat; }
     virtual long long GetInteger() const;
-    virtual const FPF* GetFloat() const;
+    virtual FPF GetFloat();
     virtual Type GetNumericType() const { return type; }
     static bool Start(const std::string& line);
     static void SetAnsi(bool flag) { ansi = flag; }
@@ -184,7 +183,6 @@ class IdentifierToken : public Token
 
   private:
     int keyValue;
-    bool parseKeyword;
     KeywordHash* keywordTable;
     std::string id;
     bool caseInsensitive;
@@ -198,7 +196,7 @@ class EndToken : public Token
 class ErrorToken : public Token
 {
   public:
-    ErrorToken(std::string& line) { Parse(line); }
+    ErrorToken(std::string& line) : ch(0) { Parse(line); }
     virtual bool IsError() const { return true; }
 
   protected:
@@ -223,7 +221,7 @@ class Tokenizer
         line = Line;
         currentToken = nullptr;
     }
-    const Token* Next();
+    std::shared_ptr<Token> Next();
     std::string GetString() { return line; }
     void SetString(const std::string& Line) { line = Line; }
     static void SetUnsigned(bool flag) { CharacterToken::SetUnsigned(flag); }
@@ -240,7 +238,7 @@ class Tokenizer
   private:
     KeywordHash* keywordTable;
     std::string line;
-    std::unique_ptr<Token> currentToken;
+    std::shared_ptr<Token> currentToken;
     bool caseInsensitive;
 };
 

--- a/src/ocpp/ocpp.vcxproj
+++ b/src/ocpp/ocpp.vcxproj
@@ -83,6 +83,7 @@
       </PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
       <DebugInformationFormat>EditAndContinue</DebugInformationFormat>
+      <ConformanceMode>true</ConformanceMode>
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">

--- a/src/ocpp/ppCond.cpp
+++ b/src/ocpp/ppCond.cpp
@@ -239,7 +239,7 @@ void ppCond::HandleEndIf(std::string& line)
 void ppCond::HandleDef(std::string& line, bool Else, bool negate, int lineno)
 {
     Tokenizer tk(line, nullptr);
-    const Token* t = tk.Next();
+    std::shared_ptr<Token> t = tk.Next();
     if (!t->IsIdentifier())
     {
         Errors::Error("Identifier expected");
@@ -341,7 +341,7 @@ void ppCond::HandleId(std::string& line, bool Else, bool negate, int lineno)
 {
     define->Process(line);
     Tokenizer tk(line, nullptr);
-    const Token* t = tk.Next();
+    std::shared_ptr<Token> t = tk.Next();
     bool v = t->IsIdentifier();
     if (negate)
         v = !v;
@@ -354,7 +354,7 @@ void ppCond::HandleNum(std::string& line, bool Else, bool negate, int lineno)
 {
     define->Process(line);
     Tokenizer tk(line, nullptr);
-    const Token* t = tk.Next();
+    std::shared_ptr<Token> t = tk.Next();
     bool v = t->IsNumeric();
     if (negate)
         v = !v;
@@ -367,7 +367,7 @@ void ppCond::HandleStr(std::string& line, bool Else, bool negate, int lineno)
 {
     define->Process(line);
     Tokenizer tk(line, nullptr);
-    const Token* t = tk.Next();
+    std::shared_ptr<Token> t = tk.Next();
     bool v = t->IsString();
     if (negate)
         v = !v;
@@ -380,7 +380,7 @@ void ppCond::HandleCtx(std::string& line, bool Else, bool negate, int lineno)
 {
     define->Process(line);
     Tokenizer tk(line, nullptr);
-    const Token* t = tk.Next();
+    std::shared_ptr<Token> t = tk.Next();
     bool v = false;
     if (t->IsIdentifier())
     {

--- a/src/ocpp/ppCtx.cpp
+++ b/src/ocpp/ppCtx.cpp
@@ -40,7 +40,7 @@ bool ppCtx::Check(int token, std::string& line)
 std::string ppCtx::GetId(std::string& line)
 {
     Tokenizer tk(line, nullptr);
-    const Token* t = tk.Next();
+    std::shared_ptr<Token> t = tk.Next();
     if (t->IsIdentifier())
     {
         return t->GetId();

--- a/src/ocpp/ppDefine.cpp
+++ b/src/ocpp/ppDefine.cpp
@@ -198,7 +198,7 @@ void ppDefine::DoAssign(std::string& line, bool caseInsensitive)
 {
     bool failed = false;
     Tokenizer tk(line, &defTokens);
-    const Token* next = tk.Next();
+    std::shared_ptr<Token> next = tk.Next();
     std::string name;
     if (!next->IsIdentifier())
     {
@@ -246,7 +246,7 @@ void ppDefine::DoDefine(std::string& line, bool caseInsensitive)
         }
     }
     Tokenizer tk(line, &defTokens);
-    const Token* next = tk.Next();
+    std::shared_ptr<Token> next = tk.Next();
     bool failed = false;
     bool hasEllipses = false;
     DefinitionArgList* da = nullptr;
@@ -322,7 +322,7 @@ void ppDefine::DoDefine(std::string& line, bool caseInsensitive)
 void ppDefine::DoUndefine(std::string& line)
 {
     Tokenizer tk(line, nullptr);
-    const Token* t = tk.Next();
+    std::shared_ptr<Token> t = tk.Next();
     if (!t->IsIdentifier())
     {
         Errors::Error("Expected symbol to undefine");
@@ -513,8 +513,6 @@ int ppDefine::InsertReplacementString(std::string& macro, int end, int begin, st
     int q;
     static char nullptrTOKEN[] = {TOKENIZING_PLACEHOLDER, 0};
     static char STRINGIZERTOKEN[] = {STRINGIZING_PLACEHOLDER, 0};
-    int p, r;
-    int val;
     int stringizing = false;
     q = end;
     while (q < macro.size() - 1 && isspace(macro[q]))
@@ -690,7 +688,6 @@ int ppDefine::ReplaceSegment(std::string& line, int begin, int end, int& pptr)
     int waiting = 0;
     int orig_end = end;
     int rv;
-    int size;
     int p;
     int insize, rv1;
     for (p = begin; p < end; p++)

--- a/src/ocpp/ppDefine.h
+++ b/src/ocpp/ppDefine.h
@@ -69,7 +69,7 @@ class ppDefine
                 return 0;
             return argList->size();
         }
-        DefinitionArgList* GetArg(int count)
+        DefinitionArgList* GetArg(size_t count)
         {
             if (!argList)
                 return nullptr;

--- a/src/ocpp/ppExpr.h
+++ b/src/ocpp/ppExpr.h
@@ -92,7 +92,7 @@ class ppExpr
     bool unsignedchar;
     ppDefine* define;
     std::unique_ptr<Tokenizer> tokenizer;
-    const Token* token;
+    std::shared_ptr<Token> token;
     static KeywordHash hash;
 };
 #endif

--- a/src/ocpp/ppMacro.h
+++ b/src/ocpp/ppMacro.h
@@ -102,7 +102,7 @@ class ppMacro
     PreProcessor* pp;
 
     std::vector<std::shared_ptr<MacroData>> stack;
-    std::map<std::string, MacroData*> macros;
+    std::map<std::string, std::shared_ptr<MacroData>> macros;
     int nextMacro;
 };
 

--- a/src/ocpp/ppMacro.h
+++ b/src/ocpp/ppMacro.h
@@ -58,7 +58,7 @@ class ppMacro
     bool Invoke(std::string name, std::string line);
     int GetMacroId()
     {
-        MacroData* p = GetTopMacro();
+        std::shared_ptr<MacroData> p = GetTopMacro();
         if (p)
             return p->id;
         else
@@ -66,7 +66,7 @@ class ppMacro
     }
     int GetMacroMax()
     {
-        MacroData* p = GetTopMacro();
+        std::shared_ptr<MacroData> p = GetTopMacro();
         if (p)
             return p->argmax;
         else
@@ -74,7 +74,7 @@ class ppMacro
     }
     std::vector<std::string>* GetMacroArgs()
     {
-        MacroData* p = GetTopMacro();
+        std::shared_ptr<MacroData> p = GetTopMacro();
         if (p)
             return &p->args;
         else
@@ -92,7 +92,7 @@ class ppMacro
     bool HandleMacro(std::string& line, bool caseInsensitive);
     bool HandleEndMacro();
     bool HandleRotate(std::string& line);
-    MacroData* GetTopMacro();
+    std::shared_ptr<MacroData> GetTopMacro();
     void reverse(std::vector<std::string>& x, int offs, int len);
 
   private:
@@ -101,7 +101,7 @@ class ppMacro
     ppExpr expr;
     PreProcessor* pp;
 
-    std::vector<std::unique_ptr<MacroData>> stack;
+    std::vector<std::shared_ptr<MacroData>> stack;
     std::map<std::string, MacroData*> macros;
     int nextMacro;
 };

--- a/src/ocpp/ppPragma.cpp
+++ b/src/ocpp/ppPragma.cpp
@@ -58,7 +58,7 @@ bool ppPragma::Check(int token, const std::string& args)
 void ppPragma::ParsePragma(const std::string& args)
 {
     Tokenizer tk(args, &hash);
-    const Token* id = tk.Next();
+    std::shared_ptr<Token> id = tk.Next();
     if (id->IsIdentifier())
     {
         std::string str = id->GetId();
@@ -88,11 +88,11 @@ void ppPragma::ParsePragma(const std::string& args)
 }
 void ppPragma::HandleSTDC(Tokenizer& tk)
 {
-    const Token* token = tk.Next();
+    std::shared_ptr<Token> token = tk.Next();
     if (token && token->IsIdentifier())
     {
         std::string name = token->GetId();
-        const Token* tokenCmd = tk.Next();
+        std::shared_ptr<Token> tokenCmd = tk.Next();
         if (tokenCmd && tokenCmd->IsIdentifier())
         {
             const char* val = tokenCmd->GetId().c_str();
@@ -122,7 +122,7 @@ void ppPragma::HandleSTDC(Tokenizer& tk)
 }
 void ppPragma::HandlePack(Tokenizer& tk)
 {
-    const Token* tok = tk.Next();
+    std::shared_ptr<Token> tok = tk.Next();
     if (tok && tok->GetKeyword() == openpa)
     {
         tok = tk.Next();
@@ -159,11 +159,11 @@ void ppPragma::HandleWarning(Tokenizer& tk)
 }
 void ppPragma::HandleSR(Tokenizer& tk, bool startup)
 {
-    const Token* name = tk.Next();
+    std::shared_ptr<Token> name = tk.Next();
     if (name && name->IsIdentifier())
     {
         std::string id = name->GetId();
-        const Token* prio = tk.Next();
+        std::shared_ptr<Token> prio = tk.Next();
         if (prio && prio->IsNumeric() && !prio->IsFloating())
         {
             Startups::Instance()->Add(id, prio->GetInteger(), startup);
@@ -249,11 +249,11 @@ void ppPragma::HandleLibrary(Tokenizer& tk)
 }
 void ppPragma::HandleAlias(Tokenizer& tk)
 {
-    const Token* name = tk.Next();
+    std::shared_ptr<Token> name = tk.Next();
     if (name && name->IsIdentifier())
     {
         std::string id = name->GetId();
-        const Token* alias = tk.Next();
+        std::shared_ptr<Token> alias = tk.Next();
         if (alias && alias->GetKeyword() == eq)
         {
             alias = tk.Next();

--- a/src/ogrep/ogrep.vcxproj
+++ b/src/ogrep/ogrep.vcxproj
@@ -88,6 +88,7 @@
       <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>..\ocpp;..\util;..\obj;..\sqlite3</AdditionalIncludeDirectories>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
+      <ConformanceMode>true</ConformanceMode>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>

--- a/src/oimplib/DefFile.h
+++ b/src/oimplib/DefFile.h
@@ -141,7 +141,7 @@ class DefFile
     unsigned stackSize;
     unsigned heapSize;
     Tokenizer tokenizer;
-    const Token* token;
+    std::shared_ptr<Token> token;
     std::fstream stream;
     int lineno;
     bool cdll;

--- a/src/oimplib/ImpLibMain.cpp
+++ b/src/oimplib/ImpLibMain.cpp
@@ -113,7 +113,7 @@ void ImpLibMain::AddFile(LibManager& librarian, const char* arg)
                     if (n != std::string::npos && (n == 0 || inputFile[n - 1] != '.'))
                     {
                         std::string ext = inputFile.substr(n);
-                        for (int i = 0; i < ext.size(); ++i)
+                        for (size_t i = 0; i < ext.size(); ++i)
                         {
                             ext[i] = tolower(ext[i]);
                         }
@@ -200,7 +200,7 @@ std::string ImpLibMain::GetInputFile(int argc, char** argv, bool& def)
     else
     {
         std::string ext = name.substr(npos);
-        for (int i = 0; i < ext.size(); i++)
+        for (size_t i = 0; i < ext.size(); i++)
             ext[i] = toupper(ext[i]);
         if (ext == ".DEF")
             def = true;
@@ -398,7 +398,7 @@ int ImpLibMain::Run(int argc, char** argv)
     else if (n != std::string::npos)
     {
         std::string ext = outputFile.substr(n);
-        for (int i = 0; i < ext.size(); ++i)
+        for (size_t i = 0; i < ext.size(); ++i)
         {
             ext[i] = tolower(ext[i]);
         }

--- a/src/oimplib/oimplib.vcxproj
+++ b/src/oimplib/oimplib.vcxproj
@@ -88,6 +88,7 @@
       <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;_CRT_SECURE_NO_WARNINGS;L_INT=__int64;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>..\ocpp;..\util;..\objlib;..\sqlite3;..\olib;..\exefmt</AdditionalIncludeDirectories>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
+      <ConformanceMode>true</ConformanceMode>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>

--- a/src/olib/LibDictionaryLibrarian.cpp
+++ b/src/olib/LibDictionaryLibrarian.cpp
@@ -58,7 +58,7 @@ void LibDictionary::CreateDictionary(LibFiles& files)
             {
                 if ((*si)->GetQuals() & ObjSection::virt)
                 {
-                    int j;
+                    size_t j;
                     std::string name = (*si)->GetName();
                     for (j = 0; j < name.size(); j++)
                         if (name[j] == '@')

--- a/src/olib/LibDictionaryLinker.cpp
+++ b/src/olib/LibDictionaryLinker.cpp
@@ -61,7 +61,7 @@ ObjInt LibDictionary::Lookup(FILE* stream, ObjInt dictionaryOffset, ObjInt dicti
         ObjByte* q = buf.get();
         fseek(stream, dictionaryOffset, SEEK_SET);
         fread(q, size, 1, stream);
-        char sig[4] = {'1', '0', 0, 0}, sig1[4];
+        char sig[4] = {'1', '0', 0, 0};
         if (!memcmp(sig, q, 4))
         {
             int len;

--- a/src/olib/LibFilesLibrarian.cpp
+++ b/src/olib/LibFilesLibrarian.cpp
@@ -33,7 +33,7 @@
 
 void LibFiles::Add(ObjFile& obj)
 {
-    for (int i = 0; i < files.size(); i++)
+    for (size_t i = 0; i < files.size(); i++)
         if (files[i]->name == obj.GetName())
         {
             std::cout << "Warning: module '" << files[i]->name << "' already exists in library, it won't be added"
@@ -52,7 +52,7 @@ void LibFiles::Add(const ObjString& Name)
     std::string internalName = Name;
     if (npos != std::string::npos)
         internalName = Name.substr(npos + 1);
-    for (int i = 0; i < files.size(); i++)
+    for (size_t i = 0; i < files.size(); i++)
         if (files[i]->name == internalName)
         {
             std::cout << "Warning: module '" << Name << "' already exists in library, it won't be added" << std::endl;

--- a/src/olib/olib.vcxproj
+++ b/src/olib/olib.vcxproj
@@ -88,6 +88,7 @@
       <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE; _CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>..\ocpp;..\util;..\objlib;..\sqlite3</AdditionalIncludeDirectories>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
+      <ConformanceMode>true</ConformanceMode>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>

--- a/src/olink/LinkAttribs.cpp
+++ b/src/olink/LinkAttribs.cpp
@@ -59,21 +59,3 @@ void LinkAttribs::SetFill(LinkExpression* Fill)
     std::unique_ptr<LinkExpression> temp(Fill);
     fill = std::move(temp);
 }
-
-LinkAttribs& LinkAttribs::operator=(const LinkAttribs& Attribs)
-{
-    if (Attribs.address)
-        address = std::make_unique<LinkExpression>(*Attribs.address);
-    if (Attribs.align)
-        align = std::make_unique<LinkExpression>(*Attribs.align);
-    if (Attribs.maxSize)
-        maxSize = std::make_unique<LinkExpression>(*Attribs.maxSize);
-    if (Attribs.roundSize)
-        roundSize = std::make_unique<LinkExpression>(*Attribs.roundSize);
-    if (Attribs.virtualOffset)
-        virtualOffset = std::make_unique<LinkExpression>(*Attribs.virtualOffset);
-    if (Attribs.fill)
-        fill = std::make_unique<LinkExpression>(*Attribs.fill);
-    return *this;
-}
-LinkAttribs::~LinkAttribs() {}

--- a/src/olink/LinkAttribs.cpp
+++ b/src/olink/LinkAttribs.cpp
@@ -26,36 +26,36 @@
 #include "LinkExpression.h"
 void LinkAttribs::SetAddress(LinkExpression* Address)
 {
-    std::unique_ptr<LinkExpression> temp(Address);
-    address = std::move(temp);
+    std::shared_ptr<LinkExpression> temp(Address);
+    address = temp;
 }
 void LinkAttribs::SetAlign(LinkExpression* Align)
 {
-    std::unique_ptr<LinkExpression> temp(Align);
-    align = std::move(temp);
+    std::shared_ptr<LinkExpression> temp(Align);
+    align = temp;
 }
 void LinkAttribs::SetMaxSize(LinkExpression* Size)
 {
-    std::unique_ptr<LinkExpression> temp(Size);
-    maxSize = std::move(temp);
+    std::shared_ptr<LinkExpression> temp(Size);
+    maxSize = temp;
 }
 void LinkAttribs::SetSize(LinkExpression* Size)
 {
-    std::unique_ptr<LinkExpression> temp(Size);
-    size = std::move(temp);
+    std::shared_ptr<LinkExpression> temp(Size);
+    size = temp;
 }
 void LinkAttribs::SetRoundSize(LinkExpression* RoundSize)
 {
-    std::unique_ptr<LinkExpression> temp(RoundSize);
-    roundSize = std::move(temp);
+    std::shared_ptr<LinkExpression> temp(RoundSize);
+    roundSize = temp;
 }
 void LinkAttribs::SetVirtualOffset(LinkExpression* VirtualOffset)
 {
-    std::unique_ptr<LinkExpression> temp(VirtualOffset);
-    virtualOffset = std::move(temp);
+    std::shared_ptr<LinkExpression> temp(VirtualOffset);
+    virtualOffset = temp;
 }
 void LinkAttribs::SetFill(LinkExpression* Fill)
 {
-    std::unique_ptr<LinkExpression> temp(Fill);
-    fill = std::move(temp);
+    std::shared_ptr<LinkExpression> temp(Fill);
+    fill = temp;
 }

--- a/src/olink/LinkAttribs.h
+++ b/src/olink/LinkAttribs.h
@@ -42,7 +42,6 @@ class LinkAttribs
         fill(nullptr)
     {
     }
-    ~LinkAttribs() = default;
     ObjInt GetAddress()
     {
         if (address)

--- a/src/olink/LinkAttribs.h
+++ b/src/olink/LinkAttribs.h
@@ -42,8 +42,7 @@ class LinkAttribs
         fill(nullptr)
     {
     }
-    ~LinkAttribs();
-    LinkAttribs& operator=(const LinkAttribs& Attribs);
+    ~LinkAttribs() = default;
     ObjInt GetAddress()
     {
         if (address)
@@ -98,13 +97,13 @@ class LinkAttribs
     bool GetHasFill() { return fill != nullptr; }
 
   private:
-    std::unique_ptr<LinkExpression> address;
-    std::unique_ptr<LinkExpression> align;
-    std::unique_ptr<LinkExpression> maxSize;
-    std::unique_ptr<LinkExpression> roundSize;
-    std::unique_ptr<LinkExpression> virtualOffset;
-    std::unique_ptr<LinkExpression> size;
-    std::unique_ptr<LinkExpression> fill;
+    std::shared_ptr<LinkExpression> address;
+    std::shared_ptr<LinkExpression> align;
+    std::shared_ptr<LinkExpression> maxSize;
+    std::shared_ptr<LinkExpression> roundSize;
+    std::shared_ptr<LinkExpression> virtualOffset;
+    std::shared_ptr<LinkExpression> size;
+    std::shared_ptr<LinkExpression> fill;
 };
 
 #endif

--- a/src/olink/LinkDebugFile.cpp
+++ b/src/olink/LinkDebugFile.cpp
@@ -292,10 +292,10 @@ void LinkDebugFile::PushCPPName(ObjString name, int n)
 {
     if (name.find("@") != std::string::npos)
     {
-        int first = 0;
-        int last = name.size();
-        int nested = 0;
-        for (int i = 0; i < name.size(); i++)
+        size_t first = 0;
+        size_t last = name.size();
+        size_t nested = 0;
+        for (size_t i = 0; i < name.size(); i++)
         {
             if (name[i] == '@')
             {
@@ -352,7 +352,7 @@ int LinkDebugFile::GetSQLNameId(ObjString name)
 bool LinkDebugFile::WriteNamesTable()
 {
     std::vector<sqlite3_int64> v;
-    for (int i = 0; i < nameList.size(); i++)
+    for (size_t i = 0; i < nameList.size(); i++)
     {
         v.push_back(i + 1);
     }

--- a/src/olink/LinkExpression.h
+++ b/src/olink/LinkExpression.h
@@ -80,7 +80,7 @@ class LinkExpression
     int GetSection() { return sect; }
     static bool EnterSymbol(LinkExpressionSymbol* Symbol, bool removeOld = false);
     static LinkExpressionSymbol* FindSymbol(const std::string& name);
-    typedef std::set<LinkExpressionSymbol*, leltcompare>::iterator iterator;
+    using iterator = std::set<LinkExpressionSymbol*, leltcompare>::iterator;
     static iterator begin() { return symbols.begin(); }
     static iterator end() { return symbols.end(); }
     ObjInt Eval(ObjInt pc);

--- a/src/olink/LinkManager.cpp
+++ b/src/olink/LinkManager.cpp
@@ -782,7 +782,7 @@ void LinkManager::PlaceSections()
             }
         }
     }
-    catch (std::bad_exception v)
+    catch (const std::bad_exception& v)
     {
         LinkError("Cannot Evaluate items in SPC file");
         return;

--- a/src/olink/LinkMap.cpp
+++ b/src/olink/LinkMap.cpp
@@ -70,7 +70,7 @@ ObjInt LinkMap::PublicBase(ObjExpression* exp, int& group)
     find->GetSection()->SetOffset(new ObjExpression(0));  // this wrecks the link but is done last so it is ok
     return overlays[group - 1]->GetAttribs().GetAddress();
 }
-void LinkMap::ShowAttribs(std::fstream& stream, LinkAttribs& attribs, ObjInt offs, int group)
+void LinkMap::ShowAttribs(std::fstream& stream, LinkAttribs attribs, ObjInt offs, int group)
 {
     if (group > 0)
     {
@@ -110,7 +110,7 @@ void LinkMap::ShowRegionLine(std::fstream& stream, LinkRegion* region, ObjInt of
 {
     if (region)
     {
-        LinkAttribs& attribs = region->GetAttribs();
+        LinkAttribs attribs = region->GetAttribs();
         stream << "    Region: " << region->GetName();
         ShowAttribs(stream, attribs, offs, group);
     }

--- a/src/olink/LinkMap.h
+++ b/src/olink/LinkMap.h
@@ -81,7 +81,7 @@ class LinkMap
     void ShowRegionLine(std::fstream& stream, LinkRegion* region, ObjInt offs, int group);
     void ShowFileLine(std::fstream& stream, LinkRegion::OneSection* data, ObjInt offs);
     void ShowSymbol(std::fstream& stream, const MapSymbolData& symbol);
-    void ShowAttribs(std::fstream& stream, LinkAttribs& attribs, ObjInt offs, int group);
+    void ShowAttribs(std::fstream& stream, LinkAttribs attribs, ObjInt offs, int group);
     eMapType type;
     eMapMode mode;
     ObjString name;

--- a/src/olink/LinkRegion.cpp
+++ b/src/olink/LinkRegion.cpp
@@ -430,7 +430,7 @@ ObjInt LinkRegion::ArrangeOverlayed(LinkManager* manager, NamedSection* data, Ob
     // make a public for virtual sections (C++)
     if (curSection->GetQuals() & ObjSection::virt)
     {
-        int i;
+        size_t i;
         for (i = 0; i < curSection->GetName().size(); i++)
         {
             if (curSection->GetName()[i] == '@' || curSection->GetName()[i] == '_')

--- a/src/olink/LinkRegion.h
+++ b/src/olink/LinkRegion.h
@@ -78,8 +78,8 @@ class LinkRegion
     LinkOverlay* GetParent() { return parent; }
     void SetParent(LinkOverlay* Parent) { parent = Parent; }
 
-    void SetAttribs(const LinkAttribs& Attribs) { attribs = Attribs; }
-    LinkAttribs& GetAttribs() { return attribs; }
+    void SetAttribs(LinkAttribs Attribs) { attribs = Attribs; }
+    LinkAttribs GetAttribs() { return attribs; }
 
     typedef SourceFile::iterator SourceFileIterator;
 

--- a/src/olink/olink.vcxproj
+++ b/src/olink/olink.vcxproj
@@ -88,6 +88,7 @@
       <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;MICROSOFT;%(PreprocessorDefinitions); SQLITE_THREADSAFE=0</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>..\ocpp;..\util;..\objlib;..\sqlite3;..\olib</AdditionalIncludeDirectories>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
+      <ConformanceMode>true</ConformanceMode>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>

--- a/src/omake/Maker.cpp
+++ b/src/omake/Maker.cpp
@@ -578,7 +578,6 @@ int Maker::RunCommands(bool keepGoing)
     bool stop = false;
     EnvironmentStrings env;
     GetEnvironment(env);
-    int count;
     Runner runner(silent, displayOnly, ignoreResults, touch, outputType, keepResponseFiles, firstGoal, filePaths);
 
     for (auto it = depends.begin(); it != depends.end(); ++it)

--- a/src/omake/Parser.cpp
+++ b/src/omake/Parser.cpp
@@ -737,7 +737,6 @@ bool Parser::ParseRule(const std::string& left, const std::string& line)
             related = ls;
         else if (!ignoreFirstGoal && !notMain)
         {
-            size_t n;
             std::string aa = ls;
             Maker::SetFirstGoal(Eval::ExtractFirst(aa, " "));
         }

--- a/src/omake/omake.vcxproj
+++ b/src/omake/omake.vcxproj
@@ -88,6 +88,7 @@
       <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>..\ocpp;..\util;..\obj;..\sqlite3</AdditionalIncludeDirectories>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
+      <ConformanceMode>true</ConformanceMode>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>

--- a/src/omake/semaphores.h
+++ b/src/omake/semaphores.h
@@ -26,13 +26,13 @@ class Semaphore
     bool null = true;
 
   public:
-    Semaphore() : null(true) {}
+    Semaphore() : null(true), handle(), named(false) {}
     Semaphore(int value) : named(false)
     {
-        semaphore_type sem;
 #ifdef _WIN32
         handle = CreateSemaphore(nullptr, value, value, nullptr);
 #elif defined(__linux__)
+        semaphore_type sem;
         sem_init(&sem, 0, value);
         handle = &sem;
 #endif

--- a/src/onm/SymbolTable.cpp
+++ b/src/onm/SymbolTable.cpp
@@ -166,7 +166,7 @@ void SymbolTable::Load(CmdFiles& files)
             }
             else
             {
-                for (int i = 0; i < librarian.Files().size(); ++i)
+                for (size_t i = 0; i < librarian.Files().size(); ++i)
                 {
                     ObjIeeeIndexManager im1;
                     ObjFactory factory(&im1);

--- a/src/onm/SymbolTable.h
+++ b/src/onm/SymbolTable.h
@@ -1,25 +1,25 @@
 /* Software License Agreement
- * 
+ *
  *     Copyright(C) 1994-2019 David Lindauer, (LADSoft)
- * 
+ *
  *     This file is part of the Orange C Compiler package.
- * 
+ *
  *     The Orange C Compiler package is free software: you can redistribute it and/or modify
  *     it under the terms of the GNU General Public License as published by
  *     the Free Software Foundation, either version 3 of the License, or
  *     (at your option) any later version.
- * 
+ *
  *     The Orange C Compiler package is distributed in the hope that it will be useful,
  *     but WITHOUT ANY WARRANTY; without even the implied warranty of
  *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  *     GNU General Public License for more details.
- * 
+ *
  *     You should have received a copy of the GNU General Public License
  *     along with Orange C.  If not, see <http://www.gnu.org/licenses/>.
- * 
+ *
  *     contact information:
  *         email: TouchStone222@runbox.com <David Lindauer>
- * 
+ *
  */
 
 #pragma once
@@ -54,7 +54,7 @@ class Symbol
         Undefined,
         ObjFileSpecific
     };
-    Symbol() {}
+    Symbol() : offset(0), type() {}
     Symbol(std::string file, std::string name, ObjInt Offset, SymbolType Type) :
         fileName(file),
         symbolName(name),

--- a/src/orc/Dialog.cpp
+++ b/src/orc/Dialog.cpp
@@ -157,7 +157,7 @@ void Control::GetClass(RCFile& rcFile)
     {
         std::wstring str = rcFile.GetString();
         std::wstring str1 = str;
-        for (int i = 0; i < str1.size(); i++)
+        for (size_t i = 0; i < str1.size(); i++)
             str1[i] = tolower(str1[i]);
         if (str1 == L"button")
             cls.SetId(Button);

--- a/src/orc/Lexer.h
+++ b/src/orc/Lexer.h
@@ -146,7 +146,7 @@ class Lexer
     ~Lexer() {}
 
     std::string GetRestOfLine();
-    const Token* GetToken() { return token; }
+    std::shared_ptr<Token> GetToken() { return token; }
     void NextToken();
     void Reset(const std::string& line)
     {
@@ -164,7 +164,7 @@ class Lexer
     bool atEol;
     bool atEof;
     Tokenizer* tokenizer;
-    const Token* token;
+    std::shared_ptr<Token> token;
     static KeywordHash hash;
 };
 #endif  // Lexer_h

--- a/src/orc/RCData.cpp
+++ b/src/orc/RCData.cpp
@@ -48,7 +48,7 @@ void RCData::ReadRC(RCFile& rcFile)
     resInfo.SetFlags((resInfo.GetFlags() & ~ResourceInfo::Discardable) | ResourceInfo::Pure);
     resInfo.ReadRC(rcFile, false);
 
-    const Token* t = rcFile.GetToken();
+    std::shared_ptr<Token> t = rcFile.GetToken();
     if (t->GetKeyword() != Lexer::BEGIN)
     {
         data.push_back(std::make_unique<ResourceData>());

--- a/src/orc/RCFile.h
+++ b/src/orc/RCFile.h
@@ -48,7 +48,7 @@ class RCFile
     virtual ~RCFile() {}
 
     void NextToken() { lexer.NextToken(); }
-    const Token* GetToken() { return lexer.GetToken(); }
+    std::shared_ptr<Token> GetToken() { return lexer.GetToken(); }
     bool IsKeyword();
     unsigned GetTokenId();
     bool IsNumber();

--- a/src/orc/orc.vcxproj
+++ b/src/orc/orc.vcxproj
@@ -88,6 +88,7 @@
       <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;L_INT=__int64;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>..\ocpp;..\util;..\obj;..\sqlite3</AdditionalIncludeDirectories>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
+      <ConformanceMode>true</ConformanceMode>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>

--- a/src/util/CmdSwitch.cpp
+++ b/src/util/CmdSwitch.cpp
@@ -105,7 +105,7 @@ int CmdSwitchCombineString::Parse(const char* data)
 int CmdSwitchCombo::Parse(const char* data)
 {
     int rv = CmdSwitchString::Parse(data);
-    for (int i = 0; i < value.size(); i++)
+    for (size_t i = 0; i < value.size(); i++)
         if (valid.find_first_of(value[i]) == std::string::npos)
             return -1;
     selected = true;
@@ -225,7 +225,7 @@ char* CmdSwitchFile::GetStr(char* data)
         char* q = strchr(p + 1, '%');
         if (q)
         {
-            int len = q + 1 - p;
+            size_t len = q + 1 - p;
             char* name = new char[len - 1];
             memcpy(name, p + 1, len - 2);
             name[len - 2] = 0;
@@ -233,7 +233,7 @@ char* CmdSwitchFile::GetStr(char* data)
             delete[] name;
             if (env)
             {
-                int len2 = strlen(env);
+                size_t len2 = strlen(env);
                 if (len > len2)
                 {
                     strcpy(p + len2, p + len);

--- a/src/util/UTF8.cpp
+++ b/src/util/UTF8.cpp
@@ -107,25 +107,24 @@ int UTF8::Span(const char* str)
 std::string UTF8::ToUpper(const std::string& val)
 {
     std::string rv;
-    const char* str = val.c_str();
     char buf[10];
-    for (int i = 0; i < val.size();)
+    for (size_t i = 0; i < val.size();)
     {
-        if ((str[i] & 0x80) == 0)
+        if ((val[i] & 0x80) == 0)
         {
-            buf[0] = ToUpper(str[i]);
+            buf[0] = ToUpper(val[i]);
             buf[1] = 0;
             rv += buf;
             i++;
         }
         else
         {
-            int spn = CharSpan(str+i);
-            int v = Decode(str + i);
+            int spn = CharSpan(val.c_str()+i);
+            int v = Decode(val.c_str() + i);
             int q = ToUpper(v);
             if (q == v)
             {
-                memcpy(buf, str + i, spn);
+                memcpy(buf, val.c_str() + i, spn);
                 buf[spn] = 0;
             }
             else

--- a/src/util/util.vcxproj
+++ b/src/util/util.vcxproj
@@ -70,6 +70,10 @@
     <OutDir Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">$(SolutionDir)$(Configuration)\</OutDir>
     <IntDir Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">$(Configuration)\</IntDir>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <CodeAnalysisRuleSet>NativeRecommendedRules.ruleset</CodeAnalysisRuleSet>
+    <RunCodeAnalysis>false</RunCodeAnalysis>
+  </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>
       <Optimization>Disabled</Optimization>
@@ -81,6 +85,8 @@
       </PrecompiledHeader>
       <WarningLevel>Level4</WarningLevel>
       <DebugInformationFormat>EditAndContinue</DebugInformationFormat>
+      <EnablePREfast>false</EnablePREfast>
+      <ConformanceMode>true</ConformanceMode>
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">


### PR DESCRIPTION
Fix a lot of extraneously defined locals, also did a bunch of std::unique_ptr -> std::shared_ptr to better represent what the pointers are actually doing.

Most of what I've done is: remove locals that are never used, get rid of a lot of signed vs unsigned comparison warnings, and attempt to use std::shared_ptr where it's appropriate (in place of std::unique_ptr, which in the way it's currently used is terrifying and is not at all what it's meant for).

I seem to have created an error of my own or two, but since I did this all at once I sort-of screwed myself on figuring out all the changes.

On another note: I've begun using Visual Studio 2019, and oh my GOD are there a LOT of null pointer deferences, VS2019 is telling me that there's over 811 cases where null pointers can be deferenced. Which would not be good if we encounter them....