### PR TITLE
Fix using the mem* operations on FPF

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -113,3 +113,9 @@ src/.vs
 *.tst
 *.err
 *.out
+src/onm/Debug/*
+src/oimplib/Debug/*
+src/obrc/Debug/*
+src/objlib/Debug/*
+src/coff2ieee/Debug/*
+src/adl/Debug/*

--- a/src/occ/middle/iconst.cpp
+++ b/src/occ/middle/iconst.cpp
@@ -96,8 +96,6 @@ static void setFloatZero(QUAD* d)
 {
     IMODE* ip;
     FPF val;
-    memset(&val, 0, sizeof(val));
-    val.SetZero(0);
     ip = make_fimmed(ISZ_LDOUBLE, val);
     d->dc.left = ip;
     d->dc.right = 0;

--- a/src/occ/x86/outasm.cpp
+++ b/src/occ/x86/outasm.cpp
@@ -1382,7 +1382,7 @@ long queue_floatval(FPF* number, int size)
     {
         while (p)
         {
-            if (p->size == size && !memcmp(&p->floatvalue, number, sizeof(*number)))
+            if (p->size == size && (number != nullptr) && p->floatvalue == *number)
                 return p->label;
             p = p->next;
         }


### PR DESCRIPTION
I notice #377 and checked, as far as I can see there are precisely 2 instances where this happens and I've fixed them fairly simply.  (note: since when FPF is initialized setZero is called I removed the setZero call, if you want me to re-add the setZero call just in case I'm fine with it but IIRC it should still work the same)