### PR TITLE
Remove enough memset and memcpy calls that clang no longer warns us

### DIFF
--- a/src/occ/middle/iblock.cpp
+++ b/src/occ/middle/iblock.cpp
@@ -282,8 +282,7 @@ int ToQuadConst(IMODE** im)
 {
     if (*im && (*im)->mode == i_immed)
     {
-        QUAD *rv, temp;
-        memset(&temp, 0, sizeof(temp));
+        QUAD *rv, temp= QUAD();
         if (isintconst((*im)->offset))
         {
             temp.dc.opcode = i_icon;

--- a/src/occ/middle/iconst.cpp
+++ b/src/occ/middle/iconst.cpp
@@ -307,7 +307,7 @@ QUAD* ReCast(int size, QUAD* in, QUAD* newMode)
             }
             else
             {
-                memset(&newMode->dc, 0, sizeof(newMode->dc));
+                newMode->dc = _basic_dag();
                 newMode->dc.opcode = i_icon;
                 newMode->dc.v.i = i;
                 newMode->ans = make_immed(ISZ_UINT, i);
@@ -328,7 +328,7 @@ QUAD* ReCast(int size, QUAD* in, QUAD* newMode)
             }
             else
             {
-                memset(&newMode->dc, 0, sizeof(newMode->dc));
+                newMode->dc = _basic_dag();
                 newMode->dc.opcode = i_fcon;
                 newMode->dc.v.f = f;
                 newMode->ans = make_fimmed(ISZ_LDOUBLE, f);

--- a/src/occ/middle/iexpr.cpp
+++ b/src/occ/middle/iexpr.cpp
@@ -131,8 +131,7 @@ void DumpLogicalDestructors(EXPRESSION* node, SYMBOL* funcsp)
 IMODE* LookupExpression(enum i_ops op, int size, IMODE* left, IMODE* right)
 {
     IMODE* ap = nullptr;
-    QUAD head;
-    memset(&head, 0, sizeof(head));
+    QUAD head = QUAD();
     head.dc.left = left;
     head.dc.right = right;
     head.dc.opcode = op;

--- a/src/occ/middle/istren.cpp
+++ b/src/occ/middle/istren.cpp
@@ -327,7 +327,7 @@ static IMODE* StrengthConstant(QUAD* head, IMODE* im1, IMODE* im2, int size)
     ins->dc.left = im2;
     ins->dc.right = im1;
     ins->ans = InitTempOpt(size, size);
-    memset(&q1, 0, sizeof(q1));
+    q1 = QUAD();
     q1.dc.opcode = ins->dc.opcode;
     q1.dc.left = im2;
     q1.dc.right = im1;

--- a/src/occ/parse/cpplookup.cpp
+++ b/src/occ/parse/cpplookup.cpp
@@ -2478,15 +2478,11 @@ static SYMBOL* getUserConversion(int flags, TYPE* tpp, TYPE* tpa, EXPRESSION* ex
             int** lenList;
             int m = 0;
             SYMBOL *found1, *found2;
-            FUNCTIONCALL funcparams;
-            INITLIST args;
-            TYPE thistp;
-            EXPRESSION exp;
+            FUNCTIONCALL funcparams = FUNCTIONCALL();
+            INITLIST args = INITLIST();
+            TYPE thistp = TYPE();
+            EXPRESSION exp = EXPRESSION();
             lst2 = gather;
-            memset(&funcparams, 0, sizeof(funcparams));
-            memset(&args, 0, sizeof(args));
-            memset(&thistp, 0, sizeof(thistp));
-            memset(&exp, 0, sizeof(exp));
             funcparams.arguments = &args;
             args.tp = tpa;
             args.exp = &exp;
@@ -2549,7 +2545,7 @@ static SYMBOL* getUserConversion(int flags, TYPE* tpp, TYPE* tpa, EXPRESSION* ex
                 }
                 lst2 = lst2->next;
             }
-            memset(&exp, 0, sizeof(exp));
+            exp = EXPRESSION();
             exp.type = en_not_lvalue;
             for (i = 0; i < funcs; i++)
             {
@@ -3593,13 +3589,10 @@ static void getInitListConversion(TYPE* tp, INITLIST* list, TYPE* tpp, int* n, e
             }
             else
             {
-                EXPRESSION exp, *expp = &exp;
+                EXPRESSION exp = EXPRESSION(), *expp = &exp;
                 TYPE* ctype = cons->tp;
-                TYPE thistp;
-                FUNCTIONCALL funcparams;
-                memset(&exp, 0, sizeof(exp));
-                memset(&funcparams, 0, sizeof(funcparams));
-                memset(&thistp, 0, sizeof(thistp));
+                TYPE thistp = TYPE();
+                FUNCTIONCALL funcparams = FUNCTIONCALL();
                 funcparams.arguments = a;
                 exp.type = en_c_i;
                 thistp.type = bt_pointer;
@@ -3674,10 +3667,9 @@ static bool getFuncConversions(SYMBOL* sym, FUNCTIONCALL* f, TYPE* atp, SYMBOL* 
     /* takes care of THIS pointer */
     if (sym->castoperator)
     {
-        TYPE tpx;
+        TYPE tpx = TYPE();
         TYPE* tpp;
         SYMBOL* argsym = (SYMBOL*)(*hr)->p;
-        memset(&tpx, 0, sizeof(tpx));
         m = 0;
         getSingleConversion(parent->tp, basetype(sym->tp)->btp, nullptr, &m, seq, sym, userFunc ? &userFunc[n] : nullptr, false);
         m1 = m;
@@ -3731,11 +3723,10 @@ static bool getFuncConversions(SYMBOL* sym, FUNCTIONCALL* f, TYPE* atp, SYMBOL* 
                 }
                 else
                 {
-                    TYPE tpx;
+                    TYPE tpx = TYPE();
                     TYPE* tpp;
                     TYPE* tpthis = f->thistp;
                     SYMBOL* argsym = (SYMBOL*)(*hr)->p;
-                    memset(&tpx, 0, sizeof(tpx));
                     hr = &(*hr)->next;
                     tpp = argsym->tp;
                     if (!tpthis)
@@ -4588,7 +4579,7 @@ SYMBOL* MatchOverloadedFunction(TYPE* tp, TYPE** mtp, SYMBOL* sym, EXPRESSION** 
     while (castvalue(exp2))
         exp2 = exp2->left;
 
-    memset(&fpargs, 0, sizeof(fpargs));
+    fpargs = FUNCTIONCALL();
     if (hrp && (hrp->p)->thisPtr)
     {
         fpargs.thistp = (hrp->p)->tp;

--- a/src/occ/parse/expr.cpp
+++ b/src/occ/parse/expr.cpp
@@ -1480,7 +1480,9 @@ static LEXEME* expression_member(LEXEME* lex, SYMBOL* funcsp, TYPE** tp, EXPRESS
                         sp3 = sp3->mainsym;
                     if (sp4 && sp4->mainsym)
                         sp4 = sp4->mainsym;
-                        
+                        
+
+
 
 
 
@@ -2216,8 +2218,7 @@ EXPRESSION* DerivedToBase(TYPE* tpn, TYPE* tpo, EXPRESSION* exp, int flags)
             if (n == 1)
             {
                 // derived to base
-                EXPRESSION q, *v = &q;
-                memset(&q, 0, sizeof(q));
+                EXPRESSION q = EXPRESSION(), *v = &q;
                 v->type = en_c_i;
                 v = baseClassOffset(spn, spo, v);
 

--- a/src/occ/parse/init.cpp
+++ b/src/occ/parse/init.cpp
@@ -554,7 +554,7 @@ int dumpMemberPtr(SYMBOL* sym, TYPE* membertp, bool make_label)
     {
         if (sym->storage_class != sc_member && sym->storage_class != sc_mutable && sym->storage_class != sc_virtual)
             errortype(ERR_CANNOT_CONVERT_TYPE, sym->tp, membertp);
-        memset(&expx, 0, sizeof(expx));
+        expx = EXPRESSION();
         expx.type = en_c_i;
         exp = baseClassOffset(sym->parentClass, basetype(membertp)->sp, &expx);
         optimize_for_constants(&exp);

--- a/src/occ/parse/inline.cpp
+++ b/src/occ/parse/inline.cpp
@@ -381,7 +381,7 @@ EXPRESSION* inlineexpr(EXPRESSION* node, bool* fromlval)
     if (node == 0)
         return 0;
     temp = (EXPRESSION*)(EXPRESSION*)Alloc(sizeof(EXPRESSION));
-    *temp = *node;
+    memcpy((void*)temp, node, sizeof(EXPRESSION));
     switch (temp->type)
     {
         case en_thisshim:

--- a/src/occ/parse/inline.cpp
+++ b/src/occ/parse/inline.cpp
@@ -381,7 +381,7 @@ EXPRESSION* inlineexpr(EXPRESSION* node, bool* fromlval)
     if (node == 0)
         return 0;
     temp = (EXPRESSION*)(EXPRESSION*)Alloc(sizeof(EXPRESSION));
-    memcpy(temp, node, sizeof(EXPRESSION));
+    *temp = *node;
     switch (temp->type)
     {
         case en_thisshim:


### PR DESCRIPTION
This is a very basic go-through of #377 and is not extremely thorough because there's tons of calls to memcpy and memset and a lot of structures directly or indirectly reference FPFs, but it's all that clang could find.

Summary of what I did: All memset(fpfstructure, 0, sizeof(whatever)) I made to just assigning a new copy of the structure (At function lifetime end it should be freed up in stack terms anyways).

For the memcpy I replaced with an assignment.

For expr.c what happened to cause every line to change was probably line endings got screwed up somewhere and the amount of effort to figure out what screwed up where in regards to line endings is monumental due to VSCode stating that it's CRLF and I am not bothered enough to figure out the cause. But I did modify expr.cpp on line 2222 to remove a memset and replaced it with a call to a QUAD() constructor and assigned it.