### PR TITLE
Fix some documentation for easier readability online

### DIFF
--- a/doc/Technical Documentation/Compiler Intermediate Language format.md
+++ b/doc/Technical Documentation/Compiler Intermediate Language format.md
@@ -11,103 +11,104 @@ languages it is more similar to assembly languages than high level languages.
 
 As example, consider this extended hello world program:
 
-> \#include <stdio.h>
-> 
-> int main(int argc, char \*\*argv)
-> {
->   for (int i=0; i < 10; i++)
->       printf("hi %d\n", i);
-> }
-
+```c
+#include <stdio.h>
+ 
+int main(int argc, char **argv)
+{
+  for (int i=0; i < 10; i++)
+      printf("hi %d\n", i);
+}
+```
 when the /Y switch is used to compile it, the compiler dumps out the initial intermediate code representation as
 generated from parsing, and the optimizer dumps out the final intermediate code representation after all optimizations
 have been applied and registers have been assigned
 
 The initial representation looks something like this:
+```
+segment end exitseg
 
-> segment end exitseg
-> 
-> segment codeseg
-> 
-> global _main
-> 
-> 
-> global _main
-> _main:
-> ; Line 3: int main(int argc, char \*\*argv) 
-> ; Line 4: { 
-> 
-> 
->   BLOCK 1
->   PROLOGUE    unset
->   BLOCK 2
-> 
-> L_2:
->   DBG BLOCK START
->   DBG BLOCK START
->   DBG BLOCK START
->   _i:LINK(0).I =   #0.I
->   T0.I =   _i:LINK(0).I
->   CONDGO  L_7:PC ; T0.I S>= #A.I
->   BLOCK 3
-> 
-> L_5:
-> ; Line 6:         printf("hi %d\n", i); 
-> 
->   T0.I =   _i:LINK(0).I
->   PARM    T0.I
->   PARM    #L_1:PC.A
->   TAG
->   GOSUB   #_printf:PC.UI
->   PARMADJ #8.N
->   DBG BLOCK END
->   BLOCK 4
-> 
-> L_8:
->   T0.I =   _i:LINK(0).I
->   T2.I = T0.I + #1.I
->   _i:LINK(0).I =   T2.I
-> ; Line 5:     for (int i=0; i < 10; i++) 
-> 
->   BLOCK 5
-> 
+segment codeseg
+
+global _main
+
+
+global _main
+_main:
+; Line 3: int main(int argc, char **argv) 
+; Line 4: { 
+
+
+  BLOCK 1
+  PROLOGUE    unset
+  BLOCK 2
+
+L_2:
+  DBG BLOCK START
+  DBG BLOCK START
+  DBG BLOCK START
+  _i:LINK(0).I =   #0.I
+  T0.I =   _i:LINK(0).I
+  CONDGO  L_7:PC ; T0.I S>= #A.I
+  BLOCK 3
+
+L_5:
+; Line 6:         printf("hi %d\n", i); 
+
+  T0.I =   _i:LINK(0).I
+  PARM    T0.I
+  PARM    #L_1:PC.A
+  TAG
+  GOSUB   #_printf:PC.UI
+  PARMADJ #8.N
+  DBG BLOCK END
+  BLOCK 4
+
+L_8:
+  T0.I =   _i:LINK(0).I
+  T2.I = T0.I + #1.I
+  _i:LINK(0).I =   T2.I
+; Line 5:     for (int i=0; i < 10; i++) 
+
+  BLOCK 5
+
 L_6:
->   T0.I =   _i:LINK(0).I
->   CONDGO  L_5:PC ; T0.I S< #A.I
->   BLOCK 6
-> 
-> L_7:
->   DBG BLOCK END
-> ; Line 7: } 
-> 
->   DBG BLOCK END
->   RV.T3.I =   #0.I
->   GOTO    L_3:PC
->   BLOCK 7
-> 
-> L_3:
->   EPILOGUE    unset
->   RET #0.UI
-> 
-> 
-> segment end codeseg
->
-> segment stringseg
-> 
-> L_1:
-> 
->   DC.B "hi %d"
->   DC.B 0xa    
->   DC.B 0x0
->   extern _printf
->
+  T0.I =   _i:LINK(0).I
+  CONDGO  L_5:PC ; T0.I S< #A.I
+  BLOCK 6
+
+L_7:
+  DBG BLOCK END
+; Line 7: } 
+
+  DBG BLOCK END
+  RV.T3.I =   #0.I
+  GOTO    L_3:PC
+  BLOCK 7
+
+L_3:
+  EPILOGUE    unset
+  RET #0.UI
+
+
+segment end codeseg
+
+segment stringseg
+
+L_1:
+
+  DC.B "hi %d"
+  DC.B 0xa    
+  DC.B 0x0
+  extern _printf
+```
 
 Here the Txxx variables are compiler-generated temporaries; they haven't been assigned to either registers or the stack at this point.
 
 Lines such as:
-
-> T0.I  = _i:LINK(0).I
-
+```
+T0.I  = _i:LINK(0).I
+```
 assign a temporary variable from a program-defined variable.   At this point the variable is assumed to be stacked at offset 0 on the stack.
 Offsets are relative to where the stack pointer is when entering the function.  The offset will be 0 at this point because register allocation and
 stack allocation are performed in the optimizer rather than in the parser.
@@ -115,20 +116,21 @@ stack allocation are performed in the optimizer rather than in the parser.
 Here the .I means it is an integer value.  In general operands will be qualified with the value type in these types of outputs.
 
 Lines such as:
-
->   T2.I = T0.I + #1.I
-
+```
+T2.I = T0.I + #1.I
+```
 perform arithmetic functions; in this case it is adding 1 to T0 (T0 being a load of _i).
 
 Lines such as :
-
->   CONDGO  L_5:PC ; T0.I S< #A.I
-
+```
+CONDGO  L_5:PC ; T0.I S< #A.I
+```
 perform a comparison then a branch.   An x86 assembly language rendition of this instruction might be:
 
->  cmp ecx, 10
->  jl L_5
-
+```
+cmp ecx, 10
+jl L_5
+```
 assuming T0 was later stored in ECX.
 
 GOSUB, PARM, and PARMADJ go together to form a call site.   Note that when using FASTCALL, the parms are just replaced by assignments
@@ -139,133 +141,133 @@ frame required, how much space to allocate to variables, what registers to push,
 a little will be said about them.
 
 These values are assigned by the optimizer; coming out of the parser they are set to 'unset'.
-
->   PROLOGUE    unset
->   EPILOGUE    unset
-
+```
+   PROLOGUE    unset
+   EPILOGUE    unset
+```
 instructions such as this:
-
->   DC.B "string"
-
+```
+DC.B "string"
+```
 define data, in this case a sequence of bytes.   To define a integer one might do:
-
->   DC.I  4
+```
+DC.I  4
+```
 
 to define data which is a reference the address of main
-
->   DC.A  _main
-
+```
+DC.A  _main
+```
 and so forth.
 
 The BLOCK and BLOCK END statements indicate the beginning and ending of basic blocks; basic blocks will often be terminated by 
 a branch instruction.
 
 Finally, instructions like this:
-
->   RV.T3.I =   #0.I
-
+```
+RV.T3.I =   #0.I
+```
 instruct the compiler to generate the sequence required for a return value, e.g. on the x86 most integers would be moved into eax.
 Not shown here you can also have something similar after a GOSUB statement:
-
->   GOSUB  #_compute_value:PC.UI
->   PARMADJ #0.I
->   T4.I = RV.T3.I
-
+```
+GOSUB  #_compute_value:PC.UI
+PARMADJ #0.I
+T4.I = RV.T3.I
+```
 In this case the RV refers to the value returned by the function, with the assumption on the x86 that T3 would be in eax.
 
 There are other registers on the x86 that are predefined, for example EAX/EDX are used in division and some forms of multiplication.   
 When a specific register must be used it is called precolored.
 
 Not shown in this example is the indirect mode of temporary access:
-
-> T0.I  = #_i:LINK(0).I
-> T1.I = (T0.A).I
-
+```
+T0.I  = #_i:LINK(0).I
+T1.I = (T0.A).I
+```
 being the same thing as:
-
->T1.I = _i:LINK(0).I
-
+```
+T1.I = _i:LINK(0).I
+```
 This becomes more useful when explicitly calculating pointer values
 
 A second representation is dumped after the optimization is complete.   In the case of the sample program it looks something like this:
 
+```
+segment codeseg
+ 
+global _main
+ 
 
-> segment codeseg
-> 
-> global _main
-> 
-> 
-> global _main
-> _main:
-> ; Line 3: int main(int argc, char \*\*argv) 
-> ; Line 4: { 
-> 
-> 
->   BLOCK 1
->   PROLOGUE    #8000000000000008.UI,#0.UI
->   BLOCK END
->   BLOCK 2
-> 
-> L_2:
->   DBG BLOCK START
->   DBG BLOCK START
->   DBG BLOCK START
->   T3(EBX).I =   #0.I
->   BLOCK END
->   BLOCK 3
-> 
-> L_5:
-> ; Line 6:         printf("hi %d\n", i); 
-> -
->   T2(EAX).I =   T3(EBX).I
->   PARM    T2(EAX).I
->   PARM    #L_1:PC.A
->   TAG
->   GOSUB   #_printf:PC.UI
->   PARMADJ #8.N
->   DBG BLOCK END
->   BLOCK END
->   BLOCK 4
-> 
-> L_8:
->   T3(EBX).I = T3(EBX).I + #1.I
-> ; Line 5:     for (int i=0; i < 10; i++) 
-> 
->   BLOCK END
->   BLOCK 5
-> 
-> L_6:
->   T5(EAX).I =   T3(EBX).I
->   CONDGO  L_5:PC ; T5(EAX).I S< #A.I
->   BLOCK END
->   BLOCK 6
-> 
-> L_7:
->   DBG BLOCK END
-> ; Line 7: } 
-> 
->   DBG BLOCK END
->   RV.T0(EAX).I =   #0.I
->   BLOCK END
->   BLOCK 7
-> 
-> L_3:
->   EPILOGUE    #8000000000000008.UI
->   RET #0.UI
-> 
->   BLOCK END
-> 
-> segment end codeseg
-> 
-> segment stringseg
-> 
-> L_1:
-> 
->   DC.B "hi %d"
->   DC.B 0xa
->   DC.B 0x0
->   extern _printf
+global _main
+_main:
+; Line 3: int main(int argc, char **argv) 
+; Line 4: { 
 
+
+  BLOCK 1
+  PROLOGUE    #8000000000000008.UI,#0.UI
+  BLOCK END
+  BLOCK 2
+
+L_2:
+  DBG BLOCK START
+  DBG BLOCK START
+  DBG BLOCK START
+  T3(EBX).I =   #0.I
+  BLOCK END
+  BLOCK 3
+
+L_5:
+; Line 6:         printf("hi %d\n", i); 
+-
+  T2(EAX).I =   T3(EBX).I
+  PARM    T2(EAX).I
+  PARM    #L_1:PC.A
+  TAG
+  GOSUB   #_printf:PC.UI
+  PARMADJ #8.N
+  DBG BLOCK END
+  BLOCK END
+  BLOCK 4
+
+L_8:
+  T3(EBX).I = T3(EBX).I + #1.I
+; Line 5:     for (int i=0; i < 10; i++) 
+
+  BLOCK END
+  BLOCK 5
+
+L_6:
+  T5(EAX).I =   T3(EBX).I
+  CONDGO  L_5:PC ; T5(EAX).I S< #A.I
+  BLOCK END
+  BLOCK 6
+
+L_7:
+  DBG BLOCK END
+; Line 7: } 
+
+  DBG BLOCK END
+  RV.T0(EAX).I =   #0.I
+  BLOCK END
+  BLOCK 7
+
+L_3:
+  EPILOGUE    #8000000000000008.UI
+  RET #0.UI
+
+  BLOCK END
+
+segment end codeseg
+
+segment stringseg
+
+L_1:
+  DC.B "hi %d"
+  DC.B 0xa
+  DC.B 0x0
+  extern _printf
+```
 The salient differences after optimization are that it figured out that it could put _i in register EBX and
 elided various temporaries initially defined for the increment.   It also figured out what values to use for
 the prologue and epilogue; from these values one can gather one register is pushed (EBX?) and there is a stack frame
@@ -287,68 +289,68 @@ accessed.   But there are exceptions, for example the block copy will copy the e
 from one place to another.
 
 For example:
-
-> T3.A
-> _counter:RAM.I
-
+```
+T3.A
+_counter:RAM.I
+```
 here T3 is an address, and _counter is an integer.   For indirections through a temporary there are two types:
-
-> (T5.A).I
-
+```
+(T5.A).I
+```
 Here the first type will usually be .A (in a future version of the compiler it could also be .FA) and the
 second type will be the type of the data being referenced through the pointer.
 
 The complete list of types is as follows:
 
-**.N**         None
-**.BOOL**      Boolean
-**.STRING**    MSIL string
-**.OBJECT**    MSIL object
-**.A**         Address
-**.FA**        FAR pointer (not used)
-**.SA**        Segment value (not used)
-**.UC**        Unsigned character
-**.C**         Signed character
-**.U16**       16-bit value
-**.U32**       32-bit value
-**.US**        unsigned short
-**.S**         signed short
-**.UI**        unsigned int
-**.I**         signed int
-**.UNATIVE**   unsigned native int (MSIL)
-**.INATIVE**   signed native int (MSIL)
-**.UL**        unsigned long
-**.L**         signed long
-**.ULL**       unsigned long long
-**.LL**        signed long long
-**.F**         float
-**.D**         double
-**.LD**        long double
-**.IF**        imaginary float
-**.ID**        imaginary double
-**.ILD**       imaginary long double
-**.CF**        complex float
-**.CD**        complex double
-**.CLD**       complex long double
-**.BIT**       bit
+* `.N`         None
+* `.BOOL`      Boolean
+* `.STRING`    MSIL string
+* `.OBJECT`    MSIL object
+* `.A`         Address
+* `.FA`        FAR pointer (not used)
+* `.SA`        Segment value (not used)
+* `.UC`        Unsigned character
+* `.C`         Signed character
+* `.U16`       16-bit value
+* `.U32`       32-bit value
+* `.US`        unsigned short
+* `.S`         signed short
+* `.UI`        unsigned int
+* `.I`         signed int
+* `.UNATIVE`   unsigned native int (MSIL)
+* `.INATIVE`   signed native int (MSIL)
+* `.UL`        unsigned long
+* `.L`         signed long
+* `.ULL`       unsigned long long
+* `.LL`        signed long long
+* `.F`         float
+* `.D`         double
+* `.LD`        long double
+* `.IF`        imaginary float
+* `.ID`        imaginary double
+* `.ILD`       imaginary long double
+* `.CF`        complex float
+* `.CD`        complex double
+* `.CLD`       complex long double
+* `.BIT`       bit
 
 ## 2.1.2 Memory qualifiers
 
 Non temporaries usually have a memory qualifier, indicating what type of memory is being used.   For example is it an
 AUTO variable?   In RAM?   In the CODE segment?
-
-> _i:LINK(-4).I
-> _bufferPointer:RAM.A
-
+```
+_i:LINK(-4).I
+_bufferPointer:RAM.A
+```
 Valid are:
 
-**:LINK(#)**             a stacked (auto) variable or parameter
+* `:LINK(#)`             a stacked (auto) variable or parameter
     By convention, variables have a negative offset, parameters have a positive offset
-**:STRUCTELEM(#)**       a reference to a structure element (MSIL)
-**:PC**                  a reference to the code segment
-**:TLS**                 a reference to thread local storage
-**:RAM**                 a reference to RAM (variables, the data segment)
-**:ABS**                 an absolute value used as an address
+* `:STRUCTELEM(#)`       a reference to a structure element (MSIL)
+* `:PC`                  a reference to the code segment
+* `:TLS`                 a reference to thread local storage
+* `:RAM`                 a reference to RAM (variables, the data segment)
+* `:ABS`                 an absolute value used as an address
 
 ## 2.1.3 Operand expressions
 
@@ -360,21 +362,16 @@ adding or subtracting constants from addresses, or negating an expression.
 As discussed operands have types and qualifiers.   There are five types of operands.  These include constant values,
 variable values, pointer indirections, and temporary values.
 
-> T4.I
-  this is a reference to the value of a temporary variable
-> (T4.A).I
-  this is a reference to the value a temporary variable points to
-> _counter:RAM.I
-  this is a reference to a variable
-> \#_counter:RAM.I
-  this is a reference to the address of a variable
-> \#5.I
-  this is a reference to a constant value (constants are displayed as hexadecimal numbers)
+* `T4.I` A reference to the value of a temporary variable
+* `(T4.A).I` A reference to the value a temporary variable points to
+* `_counter:RAM.I` A reference to a variable
+* `#_counter:RAM.I` A reference to the address of a variable
+* `#5.I` A reference to a constant value (constants are displayed as hexadecimal numbers)
   
 which as per section 2.1.3 the constants can be added to other constants:
-
-> \#_buffer:RAM.B + 5
-
+```
+#_buffer:RAM.B + 5
+```
 
 ## 2.2.0  Intermediate instructions
 
@@ -384,175 +381,175 @@ would be the same as with 32-bit integers in the intermediate language, but migh
 helper function on an architecture with 32 bits.
 
 ## 2.2.1 Passthrough
-
-> PASSTHROUGH
-
+```
+PASSTHROUGH
+```
 The passthrough instruction is a placeholder for a programp-specified assembly language instruction.   These are 
 target-specific, and no attempt is made to display the actual instruction in these types of output files.
 
 
 ## 2.2.2 Label
-
-> L_5:
-
+```
+L_5:
+```
 Label definitions such as the one for L_5 are compiler-generated labels used for the targets of implicitly declared 
 branches such as the ones in IF-ELSE or WHILE statements.   They are also used in other situations, e.g. for SWITCH_CASE
 statements, labels targeted by the GOT instruction  or for C++ exception table information.
 
 
 ## 2.2.3 GOTO
-
-> GOTO L_6:PC
-
+```
+GOTO L_6:PC
+```
 an unconditional branch to another location
 
 ## 2.2.4 GOSUB
-
->GOSUB _compute_somthings:PC
-
+```
+GOSUB _compute_somthings:PC
+```
 a branch to a subroutine.
 
 This will usually be accompanied by PARM and PARMADJ instructions.   For example the
 C language function call:
-
+```c
 AddTwoNumbers(5, 10)
-
+```
 might be generated as follows:
-
-> PARM #10.I
-> PARM #5.I
-> GOSUB #_AddTwoNumbers:PC
-> PARMADJ #8
-
+```
+PARM #10.I
+PARM #5.I
+GOSUB #_AddTwoNumbers:PC
+PARMADJ #8
+```
 where the PARMADJ cleans the stack up after the function call.
 
 
 there is also a PARMBLOCK which pushes a structured value on the stack:
-
-> PARMBLOCK _structuredValue.A(#20)
-
+```
+PARMBLOCK _structuredValue.A(#20)
+```
 The compiler might sometimes use STACKALLOC to create space for a temporary class or structure being constructed then passed 
 to another function.   The PARMADJ would take care of cleaning up such allocations.
 
 ## 2.2.5  RET
-
-> RET 
-> RET #8
-
+```
+RET 
+RET #8
+```
 This returns from a subroutine.  Here the optional number would be used for example in WIN32 STDCALL functions (or in PASCAL functions)
 to pop the arguments off the stack after returning.
 
 ## 2.2.6 Add
-
-> T4.I = T3.I + T2.I
-
+```
+T4.I = T3.I + T2.I
+```
 Add two values and store the result in T4
 
 ## 2.2.7 Subtract
-
-> T4.I = T3.I - T2.I
-
+```
+T4.I = T3.I - T2.I
+```
 Subtract two values and store the result in T4
 
 ## 2.2.8 Unsigned divide
-
-> T4.UI = T3.UI U/ T2.UI
-
+```
+T4.UI = T3.UI U/ T2.UI
+```
 Divide two values and store the result in T4
 
 ## 2.2.9 Unsigned modulus
-
-> T4.UI = T3.UI U% T2.UI
-
+```
+T4.UI = T3.UI U% T2.UI
+```
 Divide two values and store the modulus of the result in T4
 
 ## 2.2.10 Signed divide
-
-> T4.I = T3.I S/ T2.I
-
+```
+T4.I = T3.I S/ T2.I
+```
 Divide two values and store the result in T4
 
 ## 2.2.11 Signed modulus
-
-> T4.I = T3.I S% T2.I
-
+```
+T4.I = T3.I S% T2.I
+```
 Divide two values and store the modulus of the result in T4
 
 ## 2.2.12 multiply unsigned and return high word
-
-> T4.UI = T3.UI U*H T2.UI
-
+```
+T4.UI = T3.UI U*H T2.UI
+```
 Multiply two unsigned values to an intermediate type of unsigned long long, and return the high 32 bits of the result
 
 This is used to optimize DIVIDE by constant instructions.
 
 ## 2.2.13 multiply signed and return high word
-
-> T4.I = T3.I S*H T2.I
-
+```
+T4.I = T3.I S*H T2.I
+```
 Multiply two signed values to an intermediate type of signed long long, and return the high 32 bits of the result
 
 This is used to optimize DIVIDE by constant instructions.
 
 ## 2.2.14 multiply
-
-> T4.UI = T3.UI * T2.UI
-> T4.S = T3.S * T2.S
-
+```
+T4.UI = T3.UI * T2.UI
+T4.S = T3.S * T2.S
+```
 Multiply two values and store the result in T4
 
 ## 2.2.15 shift left
-
-> T4.I = T3.I << T2.I
-
+```
+T4.I = T3.I << T2.I
+```
 Shift a value left and store the result in T4
 
 ## 2.2.16 Unsigned shift right
-
-> T4.I = T3.I UI >> T2.I
-
+```
+T4.I = T3.I UI >> T2.I
+```
 Shift a value right and store the result in T4
 
 ## 2.2.17 Signed shift right
-
-> T4.I = T3.I S>> T2.I
-
+```
+T4.I = T3.I S>> T2.I
+```
 Shift a value right and store the result in T4
 
 ## 2.2.18 Bitwise and
-
-> T4.I = T3.I & T2.I
-
+```
+T4.I = T3.I & T2.I
+```
 Take the bitwise and of two operands and store the result in T4
 
 ## 2.2.19 Bitwise or
-
-> T4.I = T3.I | T2.I
-
+```
+T4.I = T3.I | T2.I
+```
 Take the bitwise or of two operands and store the result in T4
 
 ## 2.2.19 Bitwise exclusive or
-
-> T4.I = T3.I ^ T2.I
-
+```
+T4.I = T3.I ^ T2.I
+```
 Take the bitwise exclusive or of two operands and store the result in T4
 
 ## 2.2.20 Negation
-
-> T4.I = -T3.I
-
+```
+T4.I = -T3.I
+```
 Negate a value and store the result.   This will be two's complement on many target processors.
 
 ## 2.2.21 Complement
-
-> T4.i = ~T3.I
-
+```
+T4.i = ~T3.I
+```
 Take the ones complement of a value and store the result.
 
 ## 2.2.22 assignments
-
-> T4.I = T3.I
-
+```
+T4.I = T3.I
+```
 assign one operand to be equal to another
 
 ## 2.2.23 Switch statements
@@ -563,12 +560,12 @@ part is a list of constant/Label pairs (for the cases).
 This is the entire processing of a switch in the parser and optimizer, however, the backend may be smarter and try to do something
 like generate a binary tree of conditional branches for a large list of sparse cases.  or a lookup table for a non-sparse list.
 
-
-> COSWITCH(#3.UI, T3.I, #10.UI, L3)
-> SWBRANCH(#5.I, L_5)
-> SWBRANCH(#A.I, L_6)
-> SWBRANCH(#14.I, L_7)
-
+```
+COSWITCH(#3.UI, T3.I, #10.UI, L3)
+SWBRANCH(#5.I, L_5)
+SWBRANCH(#A.I, L_6)
+SWBRANCH(#14.I, L_7)
+```
 
 here we define a switch based on the value of T3.i.   There are three case values and the spread between the lowest (5) and the highest +1 (21) is sixteen.
 From this information the backend can deduce the sparseness of the branch list.  
@@ -576,59 +573,59 @@ From this information the backend can deduce the sparseness of the branch list.
 The cases go labels 5,6,7 and the default label is 3.
 
 ## 2.2.24 block assign
-
-> T3.A BLOCK= #_structaddress:RAM.A(#20.I)
-
+```
+T3.A BLOCK= #_structaddress:RAM.A(#20.I)
+```
 move a structured value with 32 bytes from RAM to a temporary area
 
 ## 2.2.25 block clear
-
-> T3.A BLKCLR(#20.I)
-
+```
+T3.A BLKCLR(#20.I)
+```
 clear a block with 32 bytes
 
 ## 2.2.26 block compare
-
-> BLKCOMPARE:L_10:PC, T3.A, _buffer:RAM.A
-
+```
+BLKCOMPARE:L_10:PC, T3.A, _buffer:RAM.A
+```
 compare two blocks
 
 ## 2.2.27 Conditional branches
-
-> CONDGO:L_10:PC ; T3.I == #5
-
+```
+CONDGO:L_10:PC ; T3.I == #5
+```
 branch to label 10 if T3 is equal to 5.   The == may be replaced by a variety of other conditional operators.  These include:
 
 
-**U<**     unsigned less than
-**U>**     unsigned greater than
-**U>=**    unsigned greater than or equal
-**U<=**    unsigned lesl than or equal
-**==**     equality
-**!=**     inequality
-**S<**     signed less than
-**S>**     signed greater than
-**S>=**    signed greater than or equal
-**S<=**    signed less than or equal
+* `U<`     unsigned less than
+* `U>`     unsigned greater than
+* `U>=`    unsigned greater than or equal
+* `U<=`    unsigned lesl than or equal
+* `==`     equality
+* `!=`     inequality
+* `S<`     signed less than
+* `S>`     signed greater than
+* `S>=`    signed greater than or equal
+* `S<=`    signed less than or equal
 
 ## 2.2.28 Computation of equality or inequality
 
-
-> T5.I = T3.I == #5
-
+```
+T5.I = T3.I == #5
+```
 compute a boolean indicating whether the two values are equal.   The == may be replaced by a variety of other conditional operators.
 These include:
 
-**U<**     unsigned less than
-**U>**     unsigned greater than
-**U>=**    unsigned greater than or equal
-**U<=**    unsigned lesl than or equal
-**==**     equality
-**!=**     inequality
-**S<**     signed less than
-**S>**     signed greater than
-**S>=**    signed greater than or equal
-**S<=**    signed less than or equal
+* `U<`     unsigned less than
+* `U>`     unsigned greater than
+* `U>=`    unsigned greater than or equal
+* `U<=`    unsigned lesl than or equal
+* `==`     equality
+* `!=`     inequality
+* `S<`     signed less than
+* `S>`     signed greater than
+* `S>=`    signed greater than or equal
+* `S<=`    signed less than or equal
 
 ## 2.2.29 Debug blocks
 
@@ -645,10 +642,10 @@ been indicated, so they are also often used to graph the branch tree of a functi
 
 ## 2.2.31 Prologue and epilogue
 
-
-> PROLOGUE #8000000000000008, #14
-> EPILOGUE #8000000000000008, #14
-
+```
+PROLOGUE #8000000000000008, #14
+EPILOGUE #8000000000000008, #14
+```
 these give indications to the backend about the needs of the generated stack frame for a function.
 
 The first number has the high bit set if a stack frame is required; the lower bits indicate which registers that
@@ -658,221 +655,220 @@ The second number gives the amount of space to allocate for local variables.
 
 
 ## 2.2.32 Stack allocations
-
-> T3.A = STACKALLOC #C.I
-
+```
+T3.A = STACKALLOC #C.I
+```
 Allocate 12 bytes on the stack and return the new stack pointer
-
-> LOADSTACK T3.A
-
+```
+LOADSTACK T3.A
+```
 Load the stack pointer into T3.A
-
-> SAVESTACK T3.A
-
+```
+SAVESTACK T3.A
+```
 Save T3.A into the stack pointer
 
 These are used by alloca; STACKALLOC also is used in other situations.
 
 ## 2.2.33 tags
-
-> EXPR TAG 7
-
+```
+EXPR TAG 7
+```
 expression tags are used by the MSIL backend for making sure that certain types of nested expressions get
 appropriate 'pops' generated.
-
-> TAG
-
+```
+TAG
+```
 Tags are used by the MSIL backend to indicate a call site.
 
 ## 2.2.34 Windows SEH
 
 SEH tags are used to bracket windows exception handling sequences.   At the beginning of the sequence
-one of the SEH modes will be signalled, orred with #0x80.  At the end of the sequence the SEH tag will appear
-with the mode not orred with #0x80.
-
->  SEH 1
-
+one of the SEH modes will be signalled, orred with `#0x80`.  At the end of the sequence the SEH tag will appear
+with the mode not orred with `#0x80`.
+```
+SEH 1
+```
 the body of the SEH sequence is a __try block statements
-
-> SEH 2
-
+```
+SEH 2
+```
 the body of the SEH sequence is a __catch block statements
-
-> SEH 3
-
+```
+SEH 3
+```
 the body of the SEH sequence is a __fault block statements
-
-> SEH 4
-
+```
+SEH 4
+```
 the body of the SEH sequence is the __finally block statemnts
 
 ## 2.2.35 Atomics
-
-> T3.I = ATOMIC FLAG FENCE #memoryOrder, _i:RAM.I
-> T3.I = ATOMIC TEST AND SET #memoryOrder, _i:RAM.I
-> ATOMIC CLEAR _i:RAM.I
-> CMPSWP address, value, third
-> XCHG first, second
-
+```
+T3.I = ATOMIC FLAG FENCE #memoryOrder, _i:RAM.I
+T3.I = ATOMIC TEST AND SET #memoryOrder, _i:RAM.I
+ATOMIC CLEAR _i:RAM.I
+CMPSWP address, value, third
+XCHG first, second
+```
 Various atomic operations.
 
 ## 2.3.0 Data and administrative instructions
 
 
 ## 2.3.1 Segment statements
-
-> segment code
-> segment end code
-
+```
+segment code
+segment end code
+```
 brackets a sequence of code or data into a logical section.   The following predefined sections exist:
 
-**exitseg**			not in a segment
-**codeseg**			code/instructions
-**dataseg**			data/variables
-**bssxseg**			uninitialized data/variables
-**stringseg**		strings
-**constseg**		constant values (deprecated
-**tlsseg**			tls values
-**startupxseg**		sequence of functions to run at program start
-**rundownxseg**		sequence of functiosn to run at program end
-**tlssuseg**		sequence of functions to run at thread start
-**tlsrdseg**		sequence of functions to run at thread end
-**fixcseg**			code segement fixups (currently unused)
-**fixdseg**			data segment fixups (currently unused)
+* `exitseg`			not in a segment
+* `codeseg`			code/instructions
+* `dataseg`			data/variables
+* `bssxseg`			uninitialized data/variables
+* `stringseg`		strings
+* `constseg`		constant values (deprecated
+* `tlsseg`			tls values
+* `startupxseg`		sequence of functions to run at program start
+* `rundownxseg`		sequence of functiosn to run at program end
+* `tlssuseg`		sequence of functions to run at thread start
+* `tlsrdseg`		sequence of functions to run at thread end
+* `fixcseg`			code segement fixups (currently unused)
+* `fixdseg`			data segment fixups (currently unused)
 
 ## 2.3.2 Variable definitions
-
-> global _main
-> _main:
-> export _exportablefunc
-> _exportablefunc:
-
+```
+global _main
+_main:
+export _exportablefunc
+_exportablefunc:
+```
 declare a named label, and give it linkage attributes
-
-> external _rra
-> import _rra
-
+```
+external _rra
+import _rra
+```
 linkage declarations for an external variable
 
 ## 2.3.3 Label definitions
-
-> L_5:
-
+```
+L_5:
+```
 declare a compiler-generated label
 
 ## 2.3.4 reserve memory
-
-> reserve 55
-
+```
+reserve 55
+```
 reserves 55 bytes of uninitialized memory
 
 ## 2.3.5 Symbol reference
-
-> DC.A _counterVariable
-
+```
+DC.A _counterVariable
+```
 declares data which is the offset of _counterVariable
 
 ## 2.3.6 startup reference
-
-> DC.A _startupFunc, 32
-
+```
+DC.A _startupFunc, 32
+```
 Defines data which is a startup function to put in a startup or rundown table, and give it a priority
 
 ## 2.3.7 label reference
-
-> DC.A L_5
-
+```
+DC.A L_5
+```
 declares data which is the offset of a compiler-generated label
-
-> DC.I L_77 - L_3
-
+```
+DC.I L_77 - L_3
+```
 define data which is the difference between two label offsets.  Used by exception handling data generation
 
 ## 2.3.8 Define data
-
-> DC.B #77
-
+```
+DC.B #77
+```
 Defines data which is a constant.   The .B may be replaced by any of the basic types:
 
-**.BOOL**      Boolean
-**.STRING**    MSIL string
-**.OBJECT**    MSIL object
-**.A**         Address
-**.FA**        FAR pointer (not used)
-**.SA**        Segment value (not used)
-**.UC**        Unsigned character
-**.C**         Signed character
-**.U16**       16-bit value
-**.U32**       32-bit value
-**.US**        unsigned short
-**.S**         signed short
-**.UI**        unsigned int
-**.I**         signed int
-**.UNATIVE**   unsigned native int (MSIL)
-**.INATIVE**   signed native int (MSIL)
-**.UL**        unsigned long
-**.L**         signed long
-**.ULL**       unsigned long long
-**.LL**        signed long long
-**.F**         float
-**.D**         double
-**.LD**        long double
-**.IF**        imaginary float
-**.ID**        imaginary double
-**.ILD**       imaginary long double
-**.CF**        complex float
-**.CD**        complex double
-**.CLD**       complex long double
-**.BIT**       bit
+* `.BOOL`      Boolean
+* `.STRING`    MSIL string
+* `.OBJECT`    MSIL object
+* `.A`         Address
+* `.FA`        FAR pointer (not used)
+* `.SA`        Segment value (not used)
+* `.UC`        Unsigned character
+* `.C`         Signed character
+* `.U16`       16-bit value
+* `.U32`       32-bit value
+* `.US`        unsigned short
+* `.S`         signed short
+* `.UI`        unsigned int
+* `.I`         signed int
+* `.UNATIVE`   unsigned native int (MSIL)
+* `.INATIVE`   signed native int (MSIL)
+* `.UL`        unsigned long
+* `.L`         signed long
+* `.ULL`       unsigned long long
+* `.LL`        signed long long
+* `.F`         float
+* `.D`         double
+* `.LD`        long double
+* `.IF`        imaginary float
+* `.ID`        imaginary double
+* `.ILD`       imaginary long double
+* `.CF`        complex float
+* `.CD`        complex double
+* `.CLD`       complex long double
+* `.BIT`       bit
 
 Note that in the special case of "DC.B" a string constant may appear in place of the numeric constant.
-
-> DC.B "hello"
-
+```
+DC.B "hello"
+```
 ## 2.3.9 Virtual sections
-
-> virtual sectionName
-> virtual end sectionName
-
+```
+virtual sectionName
+virtual end sectionName
+```
 section name is a compiler generated name, which is off the mangled value of a C++ function name or data.
 
 ## 2.3.10 Alignment
-
-> align 4
-
+```
+align 4
+```
 aligns current section on 4-byte boundary
 
 ## 2.3.11 Virtual table thunk
-
-> [this] = [this] - 16
-> goto @myfunc$qv
-
+```
+[this] = [this] - 16
+goto @myfunc$qv
+```
 when overriding base class virtual functions with derived class virtual functions, it is sometimes necessary
 to add a thunk to adjust for the new offset of the THIS pointer of the base class within the derived class.
 
 ## 2.3.12 Import thunk
-
-> section data
-> printf_pointer DC.A L_5
-> section end data
-> section code
-> L_5:
->      goto [printf]
-
+```
+section data
+printf_pointer DC.A L_5
+section end data
+section code
+L_5:
+     goto [printf]
+```
 It is sometimes necessary to generate a thunk through the windows import table, for example for defining data
 which is supposedto be a pointer to a function in the DLL.
 
 
 ## 2.3.13 member pointers which are pointers to virtual members
-
-> GOTO [[this] + %d]
-
+```
+GOTO [[this] + %d]
+```
 used as a thunk to branch to a virtual function, when referenced from a member pointer variable.
 
 ## 2.13.14 Auto variable reference
-
-> DC.I OFFSETOF _i.Link(-4) + 0
-
+```
+DC.I OFFSETOF _i.Link(-4) + 0
+```
 defines data which is the offset from the top of the stack frame of an auto variable in a function.
 Used in exception processing to locate variables to destroy during stack unwinding.
-

--- a/doc/Technical Documentation/Compiler Intermediate Language format.md
+++ b/doc/Technical Documentation/Compiler Intermediate Language format.md
@@ -20,7 +20,7 @@ int main(int argc, char **argv)
       printf("hi %d\n", i);
 }
 ```
-when the /Y switch is used to compile it, the compiler dumps out the initial intermediate code representation as
+when the `/Y` switch is used to compile it, the compiler dumps out the initial intermediate code representation as
 generated from parsing, and the optimizer dumps out the final intermediate code representation after all optimizations
 have been applied and registers have been assigned
 
@@ -103,7 +103,7 @@ L_1:
   extern _printf
 ```
 
-Here the Txxx variables are compiler-generated temporaries; they haven't been assigned to either registers or the stack at this point.
+Here the `Txxx` variables are compiler-generated temporaries; they haven't been assigned to either registers or the stack at this point.
 
 Lines such as:
 ```
@@ -113,7 +113,7 @@ assign a temporary variable from a program-defined variable.   At this point the
 Offsets are relative to where the stack pointer is when entering the function.  The offset will be 0 at this point because register allocation and
 stack allocation are performed in the optimizer rather than in the parser.
 
-Here the .I means it is an integer value.  In general operands will be qualified with the value type in these types of outputs.
+Here the `.I` means it is an integer value.  In general operands will be qualified with the value type in these types of outputs.
 
 Lines such as:
 ```
@@ -131,10 +131,9 @@ perform a comparison then a branch.   An x86 assembly language rendition of this
 cmp ecx, 10
 jl L_5
 ```
-assuming T0 was later stored in ECX.
+assuming `T0` was later stored in ECX.
 
-GOSUB, PARM, and PARMADJ go together to form a call site.   Note that when using FASTCALL, the parms are just replaced by assignments
-to temporary variables.
+`GOSUB`, `PARM`, and `PARMADJ` go together to form a call site.   Note that when using FASTCALL, the parms are just replaced by assignments to temporary variables.
 
 the following give the backend hints about what to generate at the beginning and ending of functions.   For example is a stack
 frame required, how much space to allocate to variables, what registers to push, etc...   These are mostly target-specific although
@@ -160,7 +159,7 @@ DC.A  _main
 ```
 and so forth.
 
-The BLOCK and BLOCK END statements indicate the beginning and ending of basic blocks; basic blocks will often be terminated by 
+The `BLOCK` and `BLOCK END` statements indicate the beginning and ending of basic blocks; basic blocks will often be terminated by 
 a branch instruction.
 
 Finally, instructions like this:
@@ -168,7 +167,7 @@ Finally, instructions like this:
 RV.T3.I =   #0.I
 ```
 instruct the compiler to generate the sequence required for a return value, e.g. on the x86 most integers would be moved into eax.
-Not shown here you can also have something similar after a GOSUB statement:
+Not shown here you can also have something similar after a `GOSUB` statement:
 ```
 GOSUB  #_compute_value:PC.UI
 PARMADJ #0.I
@@ -293,11 +292,11 @@ For example:
 T3.A
 _counter:RAM.I
 ```
-here T3 is an address, and _counter is an integer.   For indirections through a temporary there are two types:
+here `T3` is an address, and `_counter` is an integer.   For indirections through a temporary there are two types:
 ```
 (T5.A).I
 ```
-Here the first type will usually be .A (in a future version of the compiler it could also be .FA) and the
+Here the first type will usually be `.A` (in a future version of the compiler it could also be `.FA`) and the
 second type will be the type of the data being referenced through the pointer.
 
 The complete list of types is as follows:
@@ -392,9 +391,9 @@ target-specific, and no attempt is made to display the actual instruction in the
 ```
 L_5:
 ```
-Label definitions such as the one for L_5 are compiler-generated labels used for the targets of implicitly declared 
-branches such as the ones in IF-ELSE or WHILE statements.   They are also used in other situations, e.g. for SWITCH_CASE
-statements, labels targeted by the GOT instruction  or for C++ exception table information.
+Label definitions such as the one for `L_5` are compiler-generated labels used for the targets of implicitly declared 
+branches such as the ones in `IF-ELSE` or `WHILE` statements.   They are also used in other situations, e.g. for `SWITCH_CASE`
+statements, labels targeted by the `GOT` instruction  or for C++ exception table information.
 
 
 ## 2.2.3 GOTO
@@ -421,15 +420,15 @@ PARM #5.I
 GOSUB #_AddTwoNumbers:PC
 PARMADJ #8
 ```
-where the PARMADJ cleans the stack up after the function call.
+where the `PARMADJ` cleans the stack up after the function call.
 
 
-there is also a PARMBLOCK which pushes a structured value on the stack:
+there is also a `PARMBLOCK` which pushes a structured value on the stack:
 ```
 PARMBLOCK _structuredValue.A(#20)
 ```
-The compiler might sometimes use STACKALLOC to create space for a temporary class or structure being constructed then passed 
-to another function.   The PARMADJ would take care of cleaning up such allocations.
+The compiler might sometimes use `STACKALLOC` to create space for a temporary class or structure being constructed then passed 
+to another function.   The `PARMADJ` would take care of cleaning up such allocations.
 
 ## 2.2.5  RET
 ```
@@ -443,37 +442,37 @@ to pop the arguments off the stack after returning.
 ```
 T4.I = T3.I + T2.I
 ```
-Add two values and store the result in T4
+Add two values and store the result in `T4`
 
 ## 2.2.7 Subtract
 ```
 T4.I = T3.I - T2.I
 ```
-Subtract two values and store the result in T4
+Subtract two values and store the result in `T4`
 
 ## 2.2.8 Unsigned divide
 ```
 T4.UI = T3.UI U/ T2.UI
 ```
-Divide two values and store the result in T4
+Divide two values and store the result in `T4`
 
 ## 2.2.9 Unsigned modulus
 ```
 T4.UI = T3.UI U% T2.UI
 ```
-Divide two values and store the modulus of the result in T4
+Divide two values and store the modulus of the result in `T4`
 
 ## 2.2.10 Signed divide
 ```
 T4.I = T3.I S/ T2.I
 ```
-Divide two values and store the result in T4
+Divide two values and store the result in `T4`
 
 ## 2.2.11 Signed modulus
 ```
 T4.I = T3.I S% T2.I
 ```
-Divide two values and store the modulus of the result in T4
+Divide two values and store the modulus of the result in `T4`
 
 ## 2.2.12 multiply unsigned and return high word
 ```
@@ -481,7 +480,7 @@ T4.UI = T3.UI U*H T2.UI
 ```
 Multiply two unsigned values to an intermediate type of unsigned long long, and return the high 32 bits of the result
 
-This is used to optimize DIVIDE by constant instructions.
+This is used to optimize `DIVIDE` by constant instructions.
 
 ## 2.2.13 multiply signed and return high word
 ```
@@ -489,50 +488,50 @@ T4.I = T3.I S*H T2.I
 ```
 Multiply two signed values to an intermediate type of signed long long, and return the high 32 bits of the result
 
-This is used to optimize DIVIDE by constant instructions.
+This is used to optimize `DIVIDE` by constant instructions.
 
 ## 2.2.14 multiply
 ```
 T4.UI = T3.UI * T2.UI
 T4.S = T3.S * T2.S
 ```
-Multiply two values and store the result in T4
+Multiply two values and store the result in `T4`
 
 ## 2.2.15 shift left
 ```
 T4.I = T3.I << T2.I
 ```
-Shift a value left and store the result in T4
+Shift a value left and store the result in `T4`
 
 ## 2.2.16 Unsigned shift right
 ```
 T4.I = T3.I UI >> T2.I
 ```
-Shift a value right and store the result in T4
+Shift a value right and store the result in `T4`
 
 ## 2.2.17 Signed shift right
 ```
 T4.I = T3.I S>> T2.I
 ```
-Shift a value right and store the result in T4
+Shift a value right and store the result in `T4`
 
 ## 2.2.18 Bitwise and
 ```
 T4.I = T3.I & T2.I
 ```
-Take the bitwise and of two operands and store the result in T4
+Take the bitwise and of two operands and store the result in `T4`
 
 ## 2.2.19 Bitwise or
 ```
 T4.I = T3.I | T2.I
 ```
-Take the bitwise or of two operands and store the result in T4
+Take the bitwise or of two operands and store the result in `T4`
 
 ## 2.2.19 Bitwise exclusive or
 ```
 T4.I = T3.I ^ T2.I
 ```
-Take the bitwise exclusive or of two operands and store the result in T4
+Take the bitwise exclusive or of two operands and store the result in `T4`
 
 ## 2.2.20 Negation
 ```
@@ -567,7 +566,7 @@ SWBRANCH(#A.I, L_6)
 SWBRANCH(#14.I, L_7)
 ```
 
-here we define a switch based on the value of T3.i.   There are three case values and the spread between the lowest (5) and the highest +1 (21) is sixteen.
+here we define a switch based on the value of `T3.i`.   There are three case values and the spread between the lowest (5) and the highest +1 (21) is sixteen.
 From this information the backend can deduce the sparseness of the branch list.  
 
 The cases go labels 5,6,7 and the default label is 3.
@@ -594,7 +593,7 @@ compare two blocks
 ```
 CONDGO:L_10:PC ; T3.I == #5
 ```
-branch to label 10 if T3 is equal to 5.   The == may be replaced by a variety of other conditional operators.  These include:
+branch to label 10 if T3 is equal to 5.   The `==` may be replaced by a variety of other conditional operators.  These include:
 
 
 * `U<`     unsigned less than
@@ -613,7 +612,7 @@ branch to label 10 if T3 is equal to 5.   The == may be replaced by a variety of
 ```
 T5.I = T3.I == #5
 ```
-compute a boolean indicating whether the two values are equal.   The == may be replaced by a variety of other conditional operators.
+compute a boolean indicating whether the two values are equal.   The `==` may be replaced by a variety of other conditional operators.
 These include:
 
 * `U<`     unsigned less than
@@ -629,13 +628,13 @@ These include:
 
 ## 2.2.29 Debug blocks
 
-The beginning and end of source code blocks are delimited by the DBG_BLOCK_START and DBG_BLOCK_END tags, for correlation of
+The beginning and end of source code blocks are delimited by the `DBG_BLOCK_START` and `DBG_BLOCK_END` tags, for correlation of
 variable declarations with positions in the code segment.   This is used by the debugger.
 
 
 ## 2.2.30 Basic blocks
 
-Basic blocks as generated by the code generator are delimited by BLOCK START and BLOCK END statements.   These blocks are used by
+Basic blocks as generated by the code generator are delimited by `BLOCK START` and `BLOCK END` statements.   These blocks are used by
 the optimizer and don't bear an obvious relationship to the blocks specified in the source code.  Instead of optimizing on a 
 per-instruction basis most optimizations are done on a per-block basis.   Blocks are guaranteed to end when a branch has 
 been indicated, so they are also often used to graph the branch tree of a function.
@@ -662,13 +661,13 @@ Allocate 12 bytes on the stack and return the new stack pointer
 ```
 LOADSTACK T3.A
 ```
-Load the stack pointer into T3.A
+Load the stack pointer into `T3.A`
 ```
 SAVESTACK T3.A
 ```
-Save T3.A into the stack pointer
+Save `T3.A` into the stack pointer
 
-These are used by alloca; STACKALLOC also is used in other situations.
+These are used by alloca; `STACKALLOC` also is used in other situations.
 
 ## 2.2.33 tags
 ```
@@ -689,19 +688,19 @@ with the mode not orred with `#0x80`.
 ```
 SEH 1
 ```
-the body of the SEH sequence is a __try block statements
+the body of the SEH sequence is a `__try` block statements
 ```
 SEH 2
 ```
-the body of the SEH sequence is a __catch block statements
+the body of the SEH sequence is a `__catch` block statements
 ```
 SEH 3
 ```
-the body of the SEH sequence is a __fault block statements
+the body of the SEH sequence is a `__fault` block statements
 ```
 SEH 4
 ```
-the body of the SEH sequence is the __finally block statemnts
+the body of the SEH sequence is the `__finally` block statemnts
 
 ## 2.2.35 Atomics
 ```
@@ -789,7 +788,7 @@ define data which is the difference between two label offsets.  Used by exceptio
 ```
 DC.B #77
 ```
-Defines data which is a constant.   The .B may be replaced by any of the basic types:
+Defines data which is a constant.   The `.B` may be replaced by any of the basic types:
 
 * `.BOOL`      Boolean
 * `.STRING`    MSIL string
@@ -822,7 +821,7 @@ Defines data which is a constant.   The .B may be replaced by any of the basic t
 * `.CLD`       complex long double
 * `.BIT`       bit
 
-Note that in the special case of "DC.B" a string constant may appear in place of the numeric constant.
+Note that in the special case of `DC.B` a string constant may appear in place of the numeric constant.
 ```
 DC.B "hello"
 ```

--- a/doc/Technical Documentation/Compiler Intermediate Language format.md
+++ b/doc/Technical Documentation/Compiler Intermediate Language format.md
@@ -119,9 +119,9 @@ Lines such as:
 ```
 T2.I = T0.I + #1.I
 ```
-perform arithmetic functions; in this case it is adding 1 to T0 (T0 being a load of _i).
+perform arithmetic functions; in this case it is adding 1 to `T0` (`T0` being a load of '`_i`').
 
-Lines such as :
+Lines such as:
 ```
 CONDGO  L_5:PC ; T0.I S< #A.I
 ```
@@ -131,7 +131,7 @@ perform a comparison then a branch.   An x86 assembly language rendition of this
 cmp ecx, 10
 jl L_5
 ```
-assuming `T0` was later stored in ECX.
+assuming `T0` was later stored in `ECX`.
 
 `GOSUB`, `PARM`, and `PARMADJ` go together to form a call site.   Note that when using FASTCALL, the parms are just replaced by assignments to temporary variables.
 
@@ -166,16 +166,16 @@ Finally, instructions like this:
 ```
 RV.T3.I =   #0.I
 ```
-instruct the compiler to generate the sequence required for a return value, e.g. on the x86 most integers would be moved into eax.
+instruct the compiler to generate the sequence required for a return value, e.g. on the x86 most integers would be moved into `EAX`.
 Not shown here you can also have something similar after a `GOSUB` statement:
 ```
 GOSUB  #_compute_value:PC.UI
 PARMADJ #0.I
 T4.I = RV.T3.I
 ```
-In this case the RV refers to the value returned by the function, with the assumption on the x86 that T3 would be in eax.
+In this case the RV refers to the value returned by the function, with the assumption on the x86 that T3 would be in `EAX`.
 
-There are other registers on the x86 that are predefined, for example EAX/EDX are used in division and some forms of multiplication.   
+There are other registers on the x86 that are predefined, for example `EAX/EDX` are used in division and some forms of multiplication.   
 When a specific register must be used it is called precolored.
 
 Not shown in this example is the indirect mode of temporary access:
@@ -218,7 +218,7 @@ L_2:
 
 L_5:
 ; Line 6:         printf("hi %d\n", i); 
--
+
   T2(EAX).I =   T3(EBX).I
   PARM    T2(EAX).I
   PARM    #L_1:PC.A
@@ -267,9 +267,9 @@ L_1:
   DC.B 0x0
   extern _printf
 ```
-The salient differences after optimization are that it figured out that it could put _i in register EBX and
+The salient differences after optimization are that it figured out that it could put _i in register `EBX` and
 elided various temporaries initially defined for the increment.   It also figured out what values to use for
-the prologue and epilogue; from these values one can gather one register is pushed (EBX?) and there is a stack frame
+the prologue and epilogue; from these values one can gather one register is pushed (`EBX`?) and there is a stack frame
 used for referencing either variables or arguments or both.
 
 ## 2.0.0 Detailed list of instructions
@@ -343,7 +343,7 @@ _bufferPointer:RAM.A
 ```
 Valid are:
 
-* `:LINK(#)`             a stacked (auto) variable or parameter
+* `:LINK(#)`             a stacked (auto) variable or parameter  
     By convention, variables have a negative offset, parameters have a positive offset
 * `:STRUCTELEM(#)`       a reference to a structure element (MSIL)
 * `:PC`                  a reference to the code segment
@@ -408,7 +408,7 @@ GOSUB _compute_somthings:PC
 ```
 a branch to a subroutine.
 
-This will usually be accompanied by PARM and PARMADJ instructions.   For example the
+This will usually be accompanied by `PARM` and `PARMADJ` instructions.   For example the
 C language function call:
 ```c
 AddTwoNumbers(5, 10)
@@ -427,8 +427,7 @@ there is also a `PARMBLOCK` which pushes a structured value on the stack:
 ```
 PARMBLOCK _structuredValue.A(#20)
 ```
-The compiler might sometimes use `STACKALLOC` to create space for a temporary class or structure being constructed then passed 
-to another function.   The `PARMADJ` would take care of cleaning up such allocations.
+The compiler might sometimes use `STACKALLOC` to create space for a temporary class or structure being constructed then passed to another function. The `PARMADJ` would take care of cleaning up such allocations.
 
 ## 2.2.5  RET
 ```
@@ -566,7 +565,7 @@ SWBRANCH(#A.I, L_6)
 SWBRANCH(#14.I, L_7)
 ```
 
-here we define a switch based on the value of `T3.i`.   There are three case values and the spread between the lowest (5) and the highest +1 (21) is sixteen.
+here we define a switch based on the value of `T3.I`.   There are three case values and the spread between the lowest (5) and the highest +1 (21) is sixteen.
 From this information the backend can deduce the sparseness of the branch list.  
 
 The cases go labels 5,6,7 and the default label is 3.
@@ -844,7 +843,7 @@ aligns current section on 4-byte boundary
 goto @myfunc$qv
 ```
 when overriding base class virtual functions with derived class virtual functions, it is sometimes necessary
-to add a thunk to adjust for the new offset of the THIS pointer of the base class within the derived class.
+to add a thunk to adjust for the new offset of the `this` pointer of the base class within the derived class.
 
 ## 2.3.12 Import thunk
 ```

--- a/doc/Technical Documentation/IEEE-695 Object File format.md
+++ b/doc/Technical Documentation/IEEE-695 Object File format.md
@@ -4,24 +4,17 @@ This document documents the ieee695 format as used by LADSoft tools.
 
 ## 1.1.1. Introduction 
 
-This documentation gives the usage of the IEEE695 object files, as used by 
-the LADSoft tools.  This is an ASCII rendition of IEEE695, but extends 
-the functionality of the standard. 
+This documentation gives the usage of the IEEE695 object files as used by the LADSoft tools.  This is an ASCII rendition of IEEE695, but extends the functionality of the standard. 
 
 Note that most numbers used in the file format are HEX-ASCII. But some
 numbers, such as dates and the CO record identifiers, are decimal.
 
 ## 2.1.1. Brief guide to linker format 
 
-Each record in the relocatable object file starts with a two-letter 
-command and ends with a '.'. Symbols with periods in them may be embedded 
-in the text so the location of the ending period is context-sensitive. 
-Control characters such as CR/LF can be used for readability and are 
-generally assumed by the linker to occur after each '.' character at 
-the end of a record. 
+Each record in the relocatable object file starts with a two-letter command and ends with a '.'. Symbols with periods in them may be embedded in the text so the location of the ending period is context-sensitive. 
+Control characters such as CR/LF can be used for readability and are generally assumed by the linker to occur after each '.' character at the end of a record. 
 
-Checksums are kept as running additions of the ascii value of the
-characters, excluding any control characters that may be embedded.
+Checksums are kept as running additions of the ascii value of the characters, excluding any control characters that may be embedded.
 
 
 
@@ -30,27 +23,27 @@ characters, excluding any control characters that may be embedded.
 IEEE695 defines the following types of variables. In each case the '#' 
 indicates an index that is associated with the variable. 
 
-**I#**    public variable 
-**N#**    local variable (ladsoft tools assume this is FILE global) 
-**X#**    external variable
+* `I#`:    public variable 
+* `N#`:    local variable (ladsoft tools assume this is FILE global) 
+* `X#`:    external variable
 
 
 
 In addition IEEE695 defines a variable that can be used to index into 
 a relocatable section: 
 
-**R#**    relocatable section
+* `R#`:    relocatable section
 
 
 The IEEE695 spec also defines: 
 
-**L#**    the low limit of a section. 
+* `L#`:    the low limit of a section. 
 
 This is the address at which the section is relocated to and is only valid 
 if an absolute object file is output. 
 
 
-**P**     the current value of the program counter. 
+* `P`:     the current value of the program counter. 
 
 This is only valid in the LR (fixup) records.  It is derived from the low limit 
 of the section and the data previously encountered in the sections LD and LR records. 
@@ -59,9 +52,9 @@ of the section and the data previously encountered in the sections LD and LR rec
 
 The ladsoft tools also define the following extra variable types: 
 
-**A#**    an auto (stacked) variable 
-**E#**    a variable in a register 
-**Y#**    a segment value (e.g. for 8086 segmentation)
+* `A#`:    an auto (stacked) variable 
+* `E#`:    a variable in a register 
+* `Y#`:    a segment value (e.g. for 8086 segmentation)
 
 
 
@@ -72,7 +65,9 @@ an address or offset. An expression is a comma-delimited sequence of constants,
 the operators '+','-'.'*','/', and internal variables.  The elements of an expression 
 are in postfix notation, that is the expression: 
 
->     **R23,8,+**
+```
+R23,8,+
+```
 
 
 
@@ -80,7 +75,9 @@ indicates a location that is 8 bytes beyond the beginning of section 23.
 
 An expression such as: 
 
->    **P,424,+**
+```
+P,424,+
+```
 
 can be used to generate pc-relative offsets.
 
@@ -95,7 +92,9 @@ but allows characters that would normally be record internal delimiters such as
 For example to create a public variable with the name 'apple' one would
 do the following: 
 
->    **NI3,05apple.**
+```
+NI3,05apple.
+```
 
 
 
@@ -114,20 +113,24 @@ file contents.
 
 The module begin record has the following format:
 
->    **MBtranslator,filename.**
+```
+MBtranslator,filename.
+```
 
 
-**translator** is a string which identifies the translator (for example
+* `translator` is a string which identifies the translator (for example
 'Ladsoft C Compiler')
 
-**filename** is a string which gives the name of the source file.
+* `filename` is a string which gives the name of the source file.
 
 
 ## 3.2.3 Module End Record
 
 The module end record has the format:
 
->    **ME.**
+```
+ME.
+```
 
 
 Data after this record will be discarded by all object module processing programs.
@@ -138,9 +141,9 @@ Data after this record will be discarded by all object module processing program
 The date and time record gives the time at which the object file was generated.
 
 It has the format:
-
->     **DTYYYYMMDDHHMMSS.* 
-
+```
+DTYYYYMMDDHHMMSS.
+```
 
 Where all values are in decimal.
 
@@ -150,18 +153,20 @@ Where all values are in decimal.
 The architecture definition record gives basic information about the 
 processor architecture this file is targeted for. It has the format:
 
->    **ADbpmau,maus,endian.**
+```
+ADbpmau,maus,endian.
+```
 
-**bpmau** is the bits per machine architectural unit.  This is
+* `bpmau` is the bits per machine architectural unit.  This is
 usually 8 to denote a byte-oriented architecture.
 
-**maus** is the maximum number of machine architectural units the
+* `maus` is the maximum number of machine architectural units the
 processor deals with.  The LADSoft tools define this to be the
 maximimum number of machine architectural units in an address. 
 For example on the 68K this would be either 2 or 4 depending on the
 processor type and compiler settings.
 
-**endian** gives the endianness.  It is 'L' for little endian, 'B'
+* `endian` gives the endianness.  It is 'L' for little endian, 'B'
 for big endian.  Endianness is used for example when a tool needs
 to convert an LR record to an LD record when turning the object file
 into absolute format.
@@ -174,7 +179,9 @@ been modified up to this point.  Checksums can be placed anywhere;
 additionally a translator can choose not to generate them.  The format of a
 checksum record is:
 
->   **CSxx.**
+```
+CSxx.
+```
 
 
 When a checksum record is encountered the two hex digits after it give
@@ -187,14 +194,10 @@ formatting such as line feeds, carriage returns, or tabs are not counted)
 
 ## 3.2.7 Start Address Record
 
-The start address record gives the start address of the program.  The 
-linker will not allow more than one input module to have a start address; 
-however a start address is totally optional and its presence is only useful 
-when some type of loader is present to load the program and execute it.  It 
-has the format:
-
-?    **ASG,expr.**
-
+The start address record gives the start address of the program.  The linker will not allow more than one input module to have a start address; however a start address is totally optional and its presence is only useful when some type of loader is present to load the program and execute it.  It has the format:
+```
+ASG,expr.
+```
 
 The expression can be an absolute number for non-relocatable files, or
 a standard IEEE expression for relocatable files.
@@ -212,38 +215,39 @@ gives attributes for the section, and its name.  The linker may use the
 attributes and name, with possibly some other input, to combine and relocate 
 sections when generating the output.  It has the format:
 
->    **ST#,attributes,name.**
+```
+ST#,attributes,name.
+```
 
 
-Attributes are separated by ',' and are as follows: 
+Attributes are separated by a comma and are as follows: 
 
-**'A'**: an absolute section not subject to relocation.
-When this attribute is present an ASL record must be present in the input 
-file telling exactly where the section is located. 
+* `'A'`: an absolute section not subject to relocation.
+  * When this attribute is present an ASL record must be present in the input file telling exactly where the section is located. 
 
-**'B'**: a section made up of bit values
-This attribute is reserved for processors like the C167 or 8051. 
+* `'B'`: a section made up of bit values
+  * This attribute is reserved for processors like the C167 or 8051. 
 
-**'C'**: A common section. 
-Two common sections with the same name are overlayed on each other at link time. 
-Non-common sections normally follow one another. 
+* `'C'`: A common section. 
+  * Two common sections with the same name are overlayed on each other at link time. 
+  * Non-common sections normally follow one another. 
 
-**'E'**: an equal section
-Two equal sections with the same name must have exactly the same contents and 
-attributes when 'E' is present in the attribute list 
+* `'E'`: an equal section
+  * Two equal sections with the same name must have exactly the same contents and attributes when 'E' is present in the attribute list 
 
-**'M'**: maximum section
-if there are two sections with the same name, take the largest one. 
+* `'M'`: maximum section
+  * if there are two sections with the same name, take the largest one. 
 
-**'R'**: readonly (ROM) section 
-**'S'**: a non-common section
-(assumed without C or M or E) 
-**'U'**: unique section. 
-No other section can have the same name as a section with this attribute
+* `'R'`: readonly (ROM) section 
+* `'S'`: a non-common section
+  * This is assumed without C or M or E
+* `'U'`: unique section. 
+  * No other section can have the same name as a section with this attribute
 
-**'W'**: readwrite (RAM) section 
-**'X'**: executable section 
-**'Z':** section to be zeroed out
+* `'W'`: readwrite (RAM) section 
+* `'X'`: executable section 
+* `'Z':` section to be zeroed out
+
 Generally data will not be provided with the SB,LR,LD records and the runtime 
 system will use the size of the section to initialize it. (e.g. C language 
 uninitialized variables).  
@@ -254,13 +258,13 @@ In addition there are attributes which consider ordering sections with
 the same
 name. 
 
-**'N'**: 'now' order sections with this attribute first 
-**(no qualifier)**: order sections with this attribute next 
-**'P'**: 'postpone' order sections with this attribute last
+* `'N'`: 'now' order sections with this attribute first 
+* `(no qualifier)`: order sections with this attribute next 
+* `'P'`: 'postpone' order sections with this attribute last
 
 
 
-**name**
+* `name`
 is the name of a section, and is used by the linker for combining
 sections.
 
@@ -271,12 +275,14 @@ The section alignment record gives the minimum alignment required by a section.
 For example 68K processors require code to be aligned on two-byte boundaries, 
 and often data as well.  It has the format:
 
->    **SA#,alignment.**
+```
+SA#,alignment.
+```
 
 
 
-**#** is the index of the section as defined in the **ST** record
-**alignment** is the desired section alignment.  It must be a power of 2.
+* `#` is the index of the section as defined in the `ST` record
+* `alignment` is the desired section alignment.  It must be a power of 2.
 
 When the Section Type record is present without a Section Alignment
 record, the section alignment is assumed to be 1.
@@ -289,10 +295,12 @@ the size is implied by the LD and LR records, this record is required to allow
 the linker to do relocations without having read in the LD/LR records.  It has the
 format:
 
->    **ASS#,size.**
+```
+ASS#,size.
+```
 
-**#** is the index of the section as defined in the **ST** record.
-**size** is the number of
+* `#` is the index of the section as defined in the `ST` record.
+* `size` is the number of
 mau's worth of data in the section.
 
 
@@ -304,12 +312,14 @@ converted the object file into one of the HEX file formats.  It
 must be present for if the section has the 'A' attribute, but 
 otherwise should not be present.  It has the format:
 
->    **ASL#,location.**
+```
+ASL#,location.
+```
 
 
 
-**#** is the index of the section as defined in the **ST** record
-**location** is an address constantspecifying the location of the section.
+* `#` is the index of the section as defined in the `ST` record
+* `location` is an address constantspecifying the location of the section.
 
 
 ## 3.4.1 Section data
@@ -322,10 +332,12 @@ This section defines the records that are used to populate sections with data.
 
 The section begin record indicates the start of data for a section.  It has the following format:
 
->    **SB#.**
+```
+SB#.
+```
 
 
-**#** is the index of the section as defined in the **ST** record
+* `#` is the index of the section as defined in the `ST` record
 
 Subsequent LD and LR records, along with debug comment records, will
 refer to this section.  No load address is specified in any of the
@@ -339,11 +351,12 @@ The load data record loads pure data without modification.  It is a hex-dump
 of arbitrary length, but it is recommended that the data portion of each record 
 not be longer than 64 ascii characters for readability.  It has the format:
 
->    **LDxxxxxxxxxxxxxxxxxxxxxxxx.**
+```
+LDxxxxxxxxxxxxxxxxxxxxxxxx.
+```
 
 
-When the **AD** record specifies **maus=8** (byte architecture) the LD** record 
-loads bytes of data, with each byte described by two ASCII characters.
+When the `AD` record specifies `maus=8` (byte architecture) the LD record loads bytes of data, with each byte described by two ASCII characters.
 
 
 ## 3.4.4 Load Relocation record
@@ -351,7 +364,9 @@ loads bytes of data, with each byte described by two ASCII characters.
 The load relocation record indicates the target address and source size for a relocation (fixup).  
 It has the format:
 
->    **LR(expr,size).**
+```
+LR(expr,size).
+```
 
 
 The expression can be any valid expression referencing symbols or
@@ -359,8 +374,8 @@ section relative addresses, and generally calculates a relocated
 address. It could also be a constant, however, normally constants are
 going to be embedded directly in the LD statements.
 
-The size gives the size in **maus** of the expression when it is resolved
-to an absolute format, e.g. the number of maus of space that this **LR**
+The size gives the size in `maus` of the expression when it is resolved
+to an absolute format, e.g. the number of maus of space that this `LR`
 record reserves.
 
 
@@ -374,22 +389,19 @@ This section defines the records used in declaring variables.
 
 The name record associates an internal variable index with a name.  This is 
 the record that creates the variable index.  It has the format:
-
-**N$#,name.**
-
+```
+N$#,name.
+```
 (variable indexes will subsequently be used in LR records or sometimes in comment records)
 
-**$** is the type of variable:
-
-**'A'**    auto 
-**'E'**    register 
-**'I'**    public 
-**'N'**    local 
-**'X'**    external
-
-**#** is the index to assign
-
-**name** is a string specifying the programmer's name for the variable.
+* `$` is the type of variable:
+  * `'A'`    auto 
+  * `'E'`    register 
+  * `'I'`    public 
+  * `'N'`    local 
+  * `'X'`    external
+* `#` is the index to assign
+* `name` is a string specifying the programmer's name for the variable.
 
 
 ## 3.5.3 Assign Symbol record
@@ -397,19 +409,17 @@ the record that creates the variable index.  It has the format:
 The assign symbol record assigns the location for a variable or procedure, 
 for example by using a section-relative expression.  It has the format:
 
->    **AS$#,expr**.
+```
+AS$#,expr.
+```
 
 
 
-**$** is the type of variable
-
-**'I'** public 
-**'N'** local 
-
-
-**#** is the index assigned with the Name record
-
-**expr** is an expression indicating the location of the variable or
+* `$` is the type of variable:
+  * `'I'` public 
+  * `'N'` local 
+* `#` is the index assigned with the Name record
+* `expr` is an expression indicating the location of the variable or
 procedure
 
 
@@ -418,28 +428,25 @@ procedure
 The assign type record assigns the type
 of a variable.  It has the format:
 
->    **AT$#,T%.**
+```
+AT$#,T%.
+```
 
 
-**$** is the type of variable:
+* `$` is the type of variable:
+  * `'A'`    auto 
+  * `'E'`    register 
+  * `'I'`    public 
+  * `'N'`    local 
+  * `'X'`    external
 
 
-**'A'**    auto 
-**'E'**    register 
-**'I'**    public 
-**'N'**    local 
-**'X'**    external
-
-
-additionally there is a command  **ATT** which is used to construct new types.  
+additionally there is a command  `ATT` which is used to construct new types.  
 This is further defined in the section on debug information.
 
 
-**#** is the index assigned with the Name record
-
-**%** is the type index.  The type index can either be a built-in
-type or a type assigned with the **ATT** record.  It may not however
-be a type constructor.
+* `#` is the index assigned with the Name record
+* `%` is the type index.  The type index can either be a built-in type or a type assigned with the `ATT` record.  It may not however be a type constructor.
 
 
 ## 3.6.1 COMMENT records 
@@ -453,14 +460,14 @@ to the object file format.  One example use is for link pass separators.
 
 A comment record has the following format:
 
->   **CO#,string.**
+```
+CO#,string.
+```
 
 
-**#** is the comment record type in decimal
+* `#` is the comment record type in decimal
 
-**string** is any textual data associated with the comment record.  This 
-string does have a length field, and in this toolset sometimes other strings 
-with length fields are nested within it.
+* `string` is any textual data associated with the comment record.  This string does have a length field, and in this toolset sometimes other strings with length fields are nested within it.
 
 The following sections outline the comment records in use.
 
@@ -480,15 +487,21 @@ There are three link pass separators in the LADSOFT format. The given text
 for each separator can either be left blank or arbitrarily chosen; tools rely on the
 index.  Following are the defined pass separators:
 
->    **CO100,09sometext.**
+```
+CO100,09sometext.
+```
 The make pass separator. Make programs will quit processing after this. (optional) 
 
->    **CO101,09some text. **
+```
+CO101,09some text. 
+```
 The link pass separator. All declarations are
 done; two pass linkers can expect only loadable data beyond this point.
 
 
->    **CO102,09some text.**
+```
+CO102,09some text.
+```
 The browse info separator. Linker does not need
 any info after this for relocation. (optional)
 
@@ -499,27 +512,31 @@ include the import and export symbols.
 
 For an export symbol the record is as follows:
 
->    **CO200,$$type,name,qualifer.**
+```
+CO200,$$type,name,qualifer.
+```
 
 
-**$$** is the length of the string up to the '.' 
-**type** = O or N for Ordinal or by Name 
-**name** is the name of the symbol being exported 
-**qualifier** is either the ordinal or the exported name. 
+* `$$` is the length of the string up to the '.' 
+* `type` = O or N for Ordinal or by Name 
+* `name` is the name of the symbol being exported 
+* `qualifier` is either the ordinal or the exported name. 
 
 The names in this record are also strings which are further qualified
 with lengths.
 
 For an import symbol the record is as follows:
 
->    **C0201,O,$$name,qualifier,dllname.**
+```
+C0201,O,$$name,qualifier,dllname.
+```
 
 
-**$$** is the length of the string up to the '.' 
-**type** = O or N for Ordinal or by Name 
-**name** is the name of the symbol being exported 
-**qualifier** is either the ordinal or the exported name. 
-**dllname** is the name of the dll to reference.
+* `$$` is the length of the string up to the '.' 
+* `type` = O or N for Ordinal or by Name 
+* `name` is the name of the symbol being exported 
+* `qualifier` is either the ordinal or the exported name. 
+* `dllname` is the name of the dll to reference.
 
 The names in this record are also strings which are further qualified
 with lengths.
@@ -530,13 +547,15 @@ The Source file information record gives information about a source or
 include file.  It can be used for example by a make program to auto-make 
 a project, or by a debugger to reference line number information.  It has the format:
 
->   **C0300,$$index,name,time. **
+```
+C0300,$$index,name,time.
+```
 
 
-**$$** is the length of the following up to the '.' 
-**index** is the source or header file index we are assigning, 
-**name** is the name of the file, this is a string which is further qualified by a length.
-**time** is the time the file was last modified in YYYYMMDDHHMMSS format.
+* `$$` is the length of the following up to the '.' 
+* `index` is the source or header file index we are assigning, 
+* `name` is the name of the file, this is a string which is further qualified by a length.
+* `time` is the time the file was last modified in YYYYMMDDHHMMSS format.
 
 
 
@@ -564,12 +583,12 @@ information is found in the librarian section.
 For debugging, a program is assumed to have program global variables, 
 file global variables, functions, blocks within functions, and local variables 
 within blocks. For global variables, some basic debug information can be 
-extracted e.g. from the **N$**, ASI**, **ASN** and the **AT$#** declarations 
+extracted e.g. from the `N$`, `ASI`, `ASN` and the `AT$#` declarations 
 given above. 
 
 In addition to declaring types and locations, the debug information has
 to give locations at which local variables are 'live'. This debug
-information is interspersed with the **LD** and **LR** records for a section
+information is interspersed with the `LD` and `LR` records for a section
 define the layout of local data. It is handled with COMMENT-style
 records. Note that all type and debug information is not specified well
 by the IEEE695 spec and this information is heavily tools specific. 
@@ -580,41 +599,40 @@ by the IEEE695 spec and this information is heavily tools specific.
 The derived type record allows construction of new types such as structures and unions.  
 It has the format:
 
->    **ATT#,T%,type expression. **
+```
+ATT#,T%,type expression.
+```
 
 
-# is the type index assigned by the translator, which must be >= 1024
-% some type constructor such as a structure or union designator. 
-the type expression depends on the constructor used for the type, but
-is typically a base type, or a list of other types.  
+* `#`: is the type index assigned by the translator, which must be >= 1024
+* `%`: some type constructor such as a structure or union designator.
+  * the type expression depends on the constructor used for the type, but is typically a base type, or a list of other types.  
 
-T ype information is in the file header with other information about variables. 
+Type information is in the file header with other information about variables. 
 It is further specified for each constructor below:
 
 
-**0**: undefined 
-**1**: pointer: **ATT$,T1,T#.** 
+* `0`: undefined 
+* `1`: pointer: `ATT$,T1,T#.` 
 
-**$** is the translator-defined type of the pointer.
- **#** is the base type index
+* `$` is the translator-defined type of the pointer.
+* `#` is the base type index
 
 
-**2**: function:  **ATT$,T2,TR,#,argument list.** 
-**$** is the translator defined type of the function 
-**R** is the type index of the return value 
-**# **is a hexadecimal value giving the linkage: 
-  **0 **= unadorned label (assembler) 
-  **1** = C style function call 
-  **2** = stdcall style function call
-
-  **3** = pascall style function call
-
-  **4** = C++ object method 
+* `2`: function:  `ATT$,T2,TR,#,argument list.` 
+* `$` is the translator defined type of the function 
+* `R` is the type index of the return value 
+* `#` is a hexadecimal value giving the linkage: 
+  * `0`= unadorned label (assembler) 
+  * `1` = C style function call 
+  * `2` = stdcall style function call
+  * `3` = pascall style function call
+  * `4` = C++ object method 
 
 The argument list is a comma-delimited list of
-**A#**, which gives the parameters 
+`A#`, which gives the parameters 
 
-the **#** gives the references to an **NA** and **ATA** records for the variable.
+the `#` gives the references to an `NA` and `ATA` records for the variable.
 
 When an argument list is present, it will
 be interpreted according to implied rules about alignment of arguments.
@@ -625,42 +643,44 @@ little/big endianness of the processor as assigned in the AD record.
 
 
 
-**3**: typedef: **ATT$,T3,T#. **
-**$** is the translator-assigned type 
-**#** is the base type we are equating it to 
+* `3`: typedef: `ATT$,T3,T#.`
+* `$` is the translator-assigned type 
+* `#` is the base type we are equating it to 
 
-**4**: **ATT$,T4,list of base types. **
-**$** is the translator-defined type.
-The list of base types has comma-delimited elements as follows.
+* `4`: `ATT$,T4,list of base types.`
+* `$` is the translator-defined type.
 
-
-  T#,name,offset 
-  **#** is the base type 
-  **name** is the name of the field
-  **offset** is the offset from the beginning of the data for the field.
+The list of base types has comma-delimited elements as follows: 
+```
+T#,name,offset 
+```
+where:
+* `#` is the base type 
+* `name` is the name of the field
+* `offset` is the offset from the beginning of the data for the field.
 
 The last element of a structure reference may be a reference to a
 'field' record to continue the list of elements in which case it doesn't need 
 a name and offset. 
 
-**5**: union **ATT$,T5,list of base types. **
+* `5`: union `ATT$,T5,list of base types.`
 see the definition of the structure type. offset will normally be 0. 
 
-6: array **ATT$,T6,TB,TI,base,top**.
-**$** is the translator-defined type 
-**TB** is the type of the elements in the array 
-**TI** is the type of the indexes of the array (usually T42/Int for C languages) 
-**base** is the hexadecimal rendition of the low limit to the array index 
-**top** is the hexadecimal rendition of the high limit to the array index (inclusive) 
+* `6`: array `ATT$,T6,TB,TI,base,top.`
+* `$` is the translator-defined type 
+* `TB` is the type of the elements in the array 
+* `TI` is the type of the indexes of the array (usually T42/Int for C languages) 
+* `base` is the hexadecimal rendition of the low limit to the array index 
+* `top` is the hexadecimal rendition of the high limit to the array index (inclusive) 
 
 multiple array records can be cascaded together to make a
 multi-dimensional array.  In this case the first record will be
 the left-hand index in the declaration (assuming C-style declarations) 
 
-**7**: enumeration: **ATT$,T7,list of base types.** 
+* `7`: enumeration: `ATT$,T7,list of base types.` 
 see the definition of the structure type. offset will be the index of the enumerated value. 
 
-**8**: field list continuator: *ATT$,T8,list of base types.** 
+* `8`: field list continuator: `ATT$,T8,list of base types.` 
 see the definition of the structure type. this can be used at the end of a structure, 
 union, or enumerated constructor to continue the sequence of members.
 
@@ -673,60 +693,60 @@ other types are built by combining the type constructors with these base types
 and with other translator-assigned types.
 
 The type indexes for the base types are as follows: 
-**32**: void 
-**33**: pointer to void 
-**34**: boolean 
-**35**: bit 
+* `32`: void 
+* `33`: pointer to void 
+* `34`: boolean 
+* `35`: bit 
 
-**40**: char 
-**41**: short 
-**42**: int 
-**43**: long 
-**44**: long long 
+* `40`: char 
+* `41`: short 
+* `42`: int 
+* `43`: long 
+* `44`: long long 
 
-**48**: unsigned char 
-**49**: unsigned short 
-**50**: unsigned int 
-**51**: unsigned long 
-**52**: unsigned long long 
+* `48`: unsigned char 
+* `49`: unsigned short 
+* `50`: unsigned int 
+* `51`: unsigned long 
+* `52`: unsigned long long 
 
-**56**: pointer to char 
-**57**: pointer to short 
-**58**: pointer to int 
-**59**: pointer to long 
-**60**: pointer to long long 
+* `56`: pointer to char 
+* `57`: pointer to short 
+* `58`: pointer to int 
+* `59`: pointer to long 
+* `60`: pointer to long long 
 
-**64**: pointer to unsigned char 
-**65**: pointer to unsigned short 
-**66**: pointer to unsigned int 
-**67**: pointer to unsigned long 
-**68**: pointer to unsigned long long 
+* `64`: pointer to unsigned char 
+* `65`: pointer to unsigned short 
+* `66`: pointer to unsigned int 
+* `67`: pointer to unsigned long 
+* `68`: pointer to unsigned long long 
 
-**72**: float 
-**73**: double 
-**74**: long double 
+* `72`: float 
+* `73`: double 
+* `74`: long double 
 
-**80**: float (imaginary) 
-**81**: double (imaginary) 
-**82**: long double (imaginary) 
+* `80`: float (imaginary) 
+* `81`: double (imaginary) 
+* `82`: long double (imaginary) 
 
-**88**: float (complex) 
-**89**: double (complex) 
-**90**: long double (complex) 
+* `88`: float (complex) 
+* `89`: double (complex) 
+* `90`: long double (complex) 
 
-**96**: pointer to float 
-**97**: pointer to double 
-**98**: pointer to long double 
+* `96`: pointer to float 
+* `97`: pointer to double 
+* `98`: pointer to long double 
 
-**104**: pointer to float (imaginary) 
-**105**: pointer to double (imaginary) 
-**106**: pointer to long double (imaginary) 
+* `104`: pointer to float (imaginary) 
+* `105`: pointer to double (imaginary) 
+* `106`: pointer to long double (imaginary) 
 
-**112**: pointer to float (complex)
-**113**: pointer to double (complex) 
-**114**: pointer to long double(complex) 
+* `112`: pointer to float (complex)
+* `113`: pointer to double (complex) 
+* `114`: pointer to long double(complex) 
 
-**115-1023**: reserved
+* `115-1023`: reserved
 
 
 ## 4.3.1 Local variables and other debug information
@@ -739,13 +759,13 @@ and line number information
 
 These records declare the beginning of scope for a local variable.  They have 
 the following formats:
+```
+CO400,$$A#.
+CO400,$$E#. 
+CO400,$$N#.
+```
 
->    CO400,$$A#.
->    CO400,$$E#. 
->    CO400,$$N#.
-
-
-When **N#** variables are present they must have function scope, not file scope.
+When `N#` variables are present they must have function scope, not file scope.
 (e.g. a local static variable defined in a function)
 
 
@@ -754,30 +774,33 @@ When **N#** variables are present they must have function scope, not file scope.
 This record specifies the relationship between a line of code in the
 source file, and executable code in the object file.
 
->    **CO401,$$index,line.**
+```
+CO401,$$index,line.
+```
 
 
 
-**index** is the file index given in the CO300 record
-**line** is a line number, given in decimal.
+* `index` is the file index given in the CO300 record
+* `line` is a line number, given in decimal.
 
 
 ## 4.3.4 Block declarations
 
-The block declarations serve to locate the end of scope for variables 
-declared in a block.
+The block declarations serve to locate the end of scope for variables declared in a block.
 
->    **CO402.**
+```
+CO402.
+```
 
 block is beginning here. 
 
->    **CO403.**
+```
+CO403.
+```
 
  block is ending here. 
 
-variables defined after a CO402 go out of scope when the program counter hits
-the matching CO403.   Blocks can be nested.   Hitting a CO402 is equivalent to 
-putting a block on a stack, hitting a 403 pops the most recent CO402 and all 
+variables defined after a CO402 go out of scope when the program counter hits the matching CO403. Blocks can be nested. Hitting a CO402 is equivalent to putting a block on a stack, hitting a 403 pops the most recent CO402 and all 
 variables defined since then.
 
 ## 4.3.5 Function declarations
@@ -787,15 +810,23 @@ function parameters.
 
 For a function start:
 
->    **CO404,I#.**
->    **CO404,N#.** 
+```
+CO404,I#.
+```
+```
+CO404,N#.
+``` 
 
 
 For a function end.
 
 
->    **CO405,I#.**
->    **CO405,N#.** 
+```
+CO405,I#.
+```
+```
+CO405,N#.
+``` 
 
 The I and N variables specified must be declared with a type
 derived with the function constructor type.
@@ -809,31 +840,33 @@ information for the files in a program and generates a browse file database.
 
 The browse information is given as comment record type 500.  It has the following format:
 
->    **C0500,subtype,qualifiers,file index,linenumber,name. **
+```
+C0500,subtype,qualifiers,file index,linenumber,name.
+```
 
 
-**subtype** gives the type of browse information.
-**0**: This is for preprocessor definitions like #defines. 
-**1**: variable: this is some type of program variable. 
-**2**: file start: this is a file start 
-**3**: function start: this is a function start 
-**4**: function end: this is the end of a function 
-**5**: block start: this is the start of a block 
-**6**: block end: this is the end of a block 
+* `subtype` gives the type of browse information.
+  * `0`: This is for preprocessor definitions like #defines. 
+  * `1`: variable: this is some type of program variable. 
+  * `2`: file start: this is a file start 
+  * `3`: function start: this is a function start 
+  * `4`: function end: this is the end of a function 
+  * `5`: block start: this is the start of a block 
+  * `6`: block end: this is the end of a block 
 
-**qualifiers** are used for variable and function names as follows: 
-**0**: program global 
-**1**: file global 
-**2**: external 
-**3**: local variable 
-**4**: function prototype
+* `qualifiers` are used for variable and function names as follows: 
+  * `0`: program global 
+  * `1`: file global 
+  * `2`: external 
+  * `3`: local variable 
+  * `4`: function prototype
 
-**file index** gives the index assigned by the CO300 record
+* `file index` gives the index assigned by the CO300 record
 
-** line number** references the line within the given file and is given in decimal.
+* `line number` references the line within the given file and is given in decimal.
 
 
-**name** is the name of the symbol this record defines
+* `name` is the name of the symbol this record defines
 
 
 ## 6.1.1 librarian support 

--- a/doc/Technical Documentation/IEEE-695 Object File format.md
+++ b/doc/Technical Documentation/IEEE-695 Object File format.md
@@ -45,7 +45,7 @@ if an absolute object file is output.
 
 * `P`:     the current value of the program counter. 
 
-This is only valid in the LR (fixup) records.  It is derived from the low limit 
+This is only valid in the `LR` (fixup) records.  It is derived from the low limit 
 of the section and the data previously encountered in the sections `LD` and `LR` records. 
 
 
@@ -87,7 +87,7 @@ when a string such as a name or comment text is placed into the output file,
 it is preceded by a two-digit hexadecimal number that gives the length of the 
 string. This implicitly limits strings and variable names to 255 characters, 
 but allows characters that would normally be record internal delimiters such as
-',' and '.' to be embedded in the string. 
+commas and periods to be embedded in the string. 
 
 For example to create a public variable with the name 'apple' one would
 do the following: 
@@ -166,7 +166,7 @@ maximimum number of machine architectural units in an address.
 For example on the 68K this would be either 2 or 4 depending on the
 processor type and compiler settings.
 
-* `endian` gives the endianness.  It is 'L' for little endian, 'B'
+* `endian` gives the endianness.  It is '`L`' for little endian, '`B`'
 for big endian.  Endianness is used for example when a tool needs
 to convert an `LR` record to an `LD` record when turning the object file
 into absolute format.
@@ -222,33 +222,33 @@ ST#,attributes,name.
 
 Attributes are separated by a comma and are as follows: 
 
-* `'A'`: an absolute section not subject to relocation.
-  * When this attribute is present an ASL record must be present in the input file telling exactly where the section is located. 
+* '`A`': an absolute section not subject to relocation.  
+   When this attribute is present an ASL record must be present in the input file telling exactly where the section is located. 
 
-* `'B'`: a section made up of bit values
-  * This attribute is reserved for processors like the C167 or 8051. 
+* '`B`': a section made up of bit values  
+   This attribute is reserved for processors like the C167 or 8051. 
 
-* `'C'`: A common section. 
-  * Two common sections with the same name are overlayed on each other at link time. 
-  * Non-common sections normally follow one another. 
+* '`C`': A common section.  
+   Two common sections with the same name are overlayed on each other at link time.  
+   Non-common sections normally follow one another. 
 
-* `'E'`: an equal section
-  * Two equal sections with the same name must have exactly the same contents and attributes when 'E' is present in the attribute list 
+* '`E`': an equal section  
+   Two equal sections with the same name must have exactly the same contents and attributes when '`E`' is present in the attribute list 
 
-* `'M'`: maximum section
-  * if there are two sections with the same name, take the largest one. 
+* '`M`': maximum section  
+   if there are two sections with the same name, take the largest one. 
 
-* `'R'`: readonly (ROM) section 
-* `'S'`: a non-common section
-  * This is assumed without `C` or `M` or `E`
-* `'U'`: unique section. 
-  * No other section can have the same name as a section with this attribute
+* '`R`': readonly (ROM) section 
+* '`S`': a non-common section  
+   This is assumed without `C` or `M` or `E`
+* '`U`': unique section.  
+   No other section can have the same name as a section with this attribute
 
-* `'W'`: readwrite (RAM) section 
-* `'X'`: executable section 
-* `'Z':` section to be zeroed out
+* '`W`': readwrite (RAM) section 
+* '`X`': executable section 
+* '`Z`': section to be zeroed out
 
-Generally data will not be provided with the SB,LR,LD records and the runtime 
+Generally data will not be provided with the `SB`,`LR`,`LD` records and the runtime 
 system will use the size of the section to initialize it. (e.g. C language 
 uninitialized variables).  
 
@@ -258,9 +258,9 @@ In addition there are attributes which consider ordering sections with
 the same
 name. 
 
-* `'N'`: 'now' order sections with this attribute first 
+* '`N`': 'now' order sections with this attribute first 
 * `(no qualifier)`: order sections with this attribute next 
-* `'P'`: 'postpone' order sections with this attribute last
+* '`P`': 'postpone' order sections with this attribute last
 
 
 
@@ -394,12 +394,12 @@ N$#,name.
 ```
 (variable indexes will subsequently be used in `LR` records or sometimes in comment records)
 
-* `$` is the type of variable:
-  * `'A'`    auto 
-  * `'E'`    register 
-  * `'I'`    public 
-  * `'N'`    local 
-  * `'X'`    external
+* `$` is the type of variable:  
+   '`A`'    auto  
+   '`E`'    register  
+   '`I`'    public  
+   '`N`'    local  
+   '`X`'    external
 * `#` is the index to assign
 * `name` is a string specifying the programmer's name for the variable.
 
@@ -415,9 +415,9 @@ AS$#,expr.
 
 
 
-* `$` is the type of variable:
-  * `'I'` is a public variable 
-  * `'N'` is a local variable 
+* `$` is the type of variable:  
+  '`I`' is a public variable  
+  '`N`' is a local variable 
 * `#` is the index assigned with the Name record
 * `expr` is an expression indicating the location of the variable or
 procedure
@@ -433,12 +433,12 @@ AT$#,T%.
 ```
 
 
-* `$` is the type of variable:
-  * `'A'`    auto 
-  * `'E'`    register 
-  * `'I'`    public 
-  * `'N'`    local 
-  * `'X'`    external
+* `$` is the type of variable:  
+   '`A`'    auto  
+   '`E`'    register  
+   '`I`'    public  
+   '`N`'    local  
+   '`X`'    external
 
 
 additionally there is a command  `ATT` which is used to construct new types.  
@@ -604,8 +604,8 @@ ATT#,T%,type expression.
 
 
 * `#`: is the type index assigned by the translator, which must be >= 1024
-* `%`: some type constructor such as a structure or union designator.
-  * the type expression depends on the constructor used for the type, but is typically a base type, or a list of other types.  
+* `%`: some type constructor such as a structure or union designator.  
+    the type expression depends on the constructor used for the type, but is typically a base type or a list of other types.  
 
 Type information is in the file header with other information about variables. 
 It is further specified for each constructor below:
@@ -613,20 +613,17 @@ It is further specified for each constructor below:
 
 * `0`: undefined 
 * `1`: pointer: `ATT$,T1,T#.` 
-
 * `$` is the translator-defined type of the pointer.
 * `#` is the base type index
-
-
 * `2`: function:  `ATT$,T2,TR,#,argument list.` 
 * `$` is the translator defined type of the function 
 * `R` is the type index of the return value 
-* `#` is a hexadecimal value giving the linkage: 
-  * `0`= unadorned label (assembler) 
-  * `1` = C style function call 
-  * `2` = stdcall style function call
-  * `3` = pascall style function call
-  * `4` = C++ object method 
+* `#` is a hexadecimal value giving the linkage:  
+    `0` = unadorned label (assembler)  
+    `1` = C style function call  
+    `2` = stdcall style function call  
+    `3` = pascall style function call  
+    `4` = C++ object method 
 
 The argument list is a comma-delimited list of
 `A#`, which gives the parameters 
@@ -697,53 +694,66 @@ The type indexes for the base types are as follows:
 * `34`: boolean 
 * `35`: bit 
 
+&nbsp;
 * `40`: char 
 * `41`: short 
 * `42`: int 
 * `43`: long 
 * `44`: long long 
 
+&nbsp;
 * `48`: unsigned char 
 * `49`: unsigned short 
 * `50`: unsigned int 
 * `51`: unsigned long 
 * `52`: unsigned long long 
 
+&nbsp;
 * `56`: pointer to char 
 * `57`: pointer to short 
 * `58`: pointer to int 
 * `59`: pointer to long 
 * `60`: pointer to long long 
 
+&nbsp;
 * `64`: pointer to unsigned char 
 * `65`: pointer to unsigned short 
 * `66`: pointer to unsigned int 
 * `67`: pointer to unsigned long 
 * `68`: pointer to unsigned long long 
 
+&nbsp;
 * `72`: float 
 * `73`: double 
 * `74`: long double 
 
+&nbsp;
 * `80`: float (imaginary) 
 * `81`: double (imaginary) 
 * `82`: long double (imaginary) 
 
+&nbsp;
 * `88`: float (complex) 
 * `89`: double (complex) 
 * `90`: long double (complex) 
 
+&nbsp;
 * `96`: pointer to float 
 * `97`: pointer to double 
 * `98`: pointer to long double 
 
+&nbsp;
 * `104`: pointer to float (imaginary) 
 * `105`: pointer to double (imaginary) 
 * `106`: pointer to long double (imaginary) 
 
+&nbsp;
+
 * `112`: pointer to float (complex)
 * `113`: pointer to double (complex) 
 * `114`: pointer to long double(complex) 
+
+&nbsp;
 
 * `115-1023`: reserved
 
@@ -844,27 +854,22 @@ C0500,subtype,qualifiers,file index,linenumber,name.
 ```
 
 
-* `subtype` gives the type of browse information.
-  * `0`: This is for preprocessor definitions like #defines. 
-  * `1`: variable: this is some type of program variable. 
-  * `2`: file start: this is a file start 
-  * `3`: function start: this is a function start 
-  * `4`: function end: this is the end of a function 
-  * `5`: block start: this is the start of a block 
-  * `6`: block end: this is the end of a block 
-
-* `qualifiers` are used for variable and function names as follows: 
-  * `0`: program global 
-  * `1`: file global 
-  * `2`: external 
-  * `3`: local variable 
-  * `4`: function prototype
-
+* `subtype` gives the type of browse information.  
+   `0`: This is for preprocessor definitions like #defines.  
+   `1`: variable: this is some type of program variable.  
+   `2`: file start: this is a file start  
+   `3`: function start: this is a function start  
+   `4`: function end: this is the end of a function  
+   `5`: block start: this is the start of a block  
+   `6`: block end: this is the end of a block  
+* `qualifiers` are used for variable and function names as follows:  
+   `0`: program global  
+   `1`: file global  
+   `2`: external  
+   `3`: local variable  
+   `4`: function prototype
 * `file index` gives the index assigned by the CO300 record
-
 * `line number` references the line within the given file and is given in decimal.
-
-
 * `name` is the name of the symbol this record defines
 
 

--- a/doc/Technical Documentation/IEEE-695 Object File format.md
+++ b/doc/Technical Documentation/IEEE-695 Object File format.md
@@ -11,8 +11,8 @@ numbers, such as dates and the CO record identifiers, are decimal.
 
 ## 2.1.1. Brief guide to linker format 
 
-Each record in the relocatable object file starts with a two-letter command and ends with a '.'. Symbols with periods in them may be embedded in the text so the location of the ending period is context-sensitive. 
-Control characters such as CR/LF can be used for readability and are generally assumed by the linker to occur after each '.' character at the end of a record. 
+Each record in the relocatable object file starts with a two-letter command and ends with a period. Symbols with periods in them may be embedded in the text so the location of the ending period is context-sensitive. 
+Control characters such as CR/LF can be used for readability and are generally assumed by the linker to occur after each period character at the end of a record. 
 
 Checksums are kept as running additions of the ascii value of the characters, excluding any control characters that may be embedded.
 
@@ -46,7 +46,7 @@ if an absolute object file is output.
 * `P`:     the current value of the program counter. 
 
 This is only valid in the LR (fixup) records.  It is derived from the low limit 
-of the section and the data previously encountered in the sections LD and LR records. 
+of the section and the data previously encountered in the sections `LD` and `LR` records. 
 
 
 
@@ -60,7 +60,7 @@ The ladsoft tools also define the following extra variable types:
 
 ## 2.2.2 Expressions 
 
-In some cases such as in fixups/LR Records, an expression is used to specify 
+In some cases such as in fixups or `LR` Records, an expression is used to specify 
 an address or offset. An expression is a comma-delimited sequence of constants, 
 the operators '+','-'.'*','/', and internal variables.  The elements of an expression 
 are in postfix notation, that is the expression: 
@@ -168,7 +168,7 @@ processor type and compiler settings.
 
 * `endian` gives the endianness.  It is 'L' for little endian, 'B'
 for big endian.  Endianness is used for example when a tool needs
-to convert an LR record to an LD record when turning the object file
+to convert an `LR` record to an `LD` record when turning the object file
 into absolute format.
 
 
@@ -186,7 +186,7 @@ CSxx.
 
 When a checksum record is encountered the two hex digits after it give
 the sum, modulo 128, of all non-control characters after the '.' of the
-last checksum record (or start of file) and up to and including the 'S'
+last checksum record (or start of file) and up to and including the '`S`'
 of the current checksum record.   (Since it ignores control characters any
 formatting such as line feeds, carriage returns, or tabs are not counted)
 
@@ -240,7 +240,7 @@ Attributes are separated by a comma and are as follows:
 
 * `'R'`: readonly (ROM) section 
 * `'S'`: a non-common section
-  * This is assumed without C or M or E
+  * This is assumed without `C` or `M` or `E`
 * `'U'`: unique section. 
   * No other section can have the same name as a section with this attribute
 
@@ -291,8 +291,8 @@ record, the section alignment is assumed to be 1.
 ## 3.3.4 Assign Symbol record
 
 The assign size record gives the size when used with a section.  Even though 
-the size is implied by the LD and LR records, this record is required to allow 
-the linker to do relocations without having read in the LD/LR records.  It has the
+the size is implied by the `LD` and `LR` records, this record is required to allow 
+the linker to do relocations without having read in the `LD`/`LR` records.  It has the
 format:
 
 ```
@@ -309,7 +309,7 @@ mau's worth of data in the section.
 The assign location record gives the absolute location a section 
 should be loaded at.  It would be used for example by a tool that 
 converted the object file into one of the HEX file formats.  It 
-must be present for if the section has the 'A' attribute, but 
+must be present for if the section has the '`A`' attribute, but 
 otherwise should not be present.  It has the format:
 
 ```
@@ -339,10 +339,10 @@ SB#.
 
 * `#` is the index of the section as defined in the `ST` record
 
-Subsequent LD and LR records, along with debug comment records, will
+Subsequent `LD` and `LR` records, along with debug comment records, will
 refer to this section.  No load address is specified in any of the
 data records; the load address is implied by the final section location
-and preceding LD and LR records in this section.
+and preceding `LD` and `LR` records in this section.
 
 
 ## 3.4.3 Load Data record
@@ -356,7 +356,7 @@ LDxxxxxxxxxxxxxxxxxxxxxxxx.
 ```
 
 
-When the `AD` record specifies `maus=8` (byte architecture) the LD record loads bytes of data, with each byte described by two ASCII characters.
+When the `AD` record specifies `maus=8` (byte architecture) the `LD` record loads bytes of data, with each byte described by two ASCII characters.
 
 
 ## 3.4.4 Load Relocation record
@@ -392,7 +392,7 @@ the record that creates the variable index.  It has the format:
 ```
 N$#,name.
 ```
-(variable indexes will subsequently be used in LR records or sometimes in comment records)
+(variable indexes will subsequently be used in `LR` records or sometimes in comment records)
 
 * `$` is the type of variable:
   * `'A'`    auto 
@@ -416,8 +416,8 @@ AS$#,expr.
 
 
 * `$` is the type of variable:
-  * `'I'` public 
-  * `'N'` local 
+  * `'I'` is a public variable 
+  * `'N'` is a local variable 
 * `#` is the index assigned with the Name record
 * `expr` is an expression indicating the location of the variable or
 procedure
@@ -476,8 +476,7 @@ The following sections outline the comment records in use.
 ## 3.6.2 Comment records 1-99 
 
 A general comment inserted by the
-translator and discarded by other tools. For example: "CO1,16this is a
-cool program."
+translator and discarded by other tools. For example: `CO1,16this is a cool program.`
 
 
 


### PR DESCRIPTION
There's some points where we REALLY need a table but markdown as a standard (not github, github has a custom markdown) does not have table support and wants you to use HTML, which I'm far too lazy to learn HTML when 15 seconds of applying regex can get something decent and readable

For best effects of seeing the results just look at how the files themselves look in my repo, much cleaner with separated lines, don't you think?

Also of note: I'm submitting this PR for the `split` branch and not the master.