### PR TITLE
Fix include next issue #523

### DIFF
--- a/src/ocpp/ppInclude.cpp
+++ b/src/ocpp/ppInclude.cpp
@@ -277,6 +277,10 @@ std::string ppInclude::SrchPath(bool system, const std::string& name, const std:
 				// TODO: find a fix that's faster than this, if compiled with any compiler that has vectorization this should be faster than strlen
 				// A possible fix to make this faster is to use std::string but that requires more knowledge than I have atm
 				memset(buf, 0, 260);
+				if (path == nullptr)
+				{
+					return "";
+				}
 				path = RetrievePath(buf, path);
 				if (!buf) // check if we haven't hit the end of all include paths yet, if we have, break and let FindFile handle the rest
 				{
@@ -289,6 +293,10 @@ std::string ppInclude::SrchPath(bool system, const std::string& name, const std:
 		else
 		{
 			path = RetrievePath(buf, path);
+		}
+		if (path == nullptr && skipUntilDepth)
+		{
+			return "";
 		}
 		if (reachedEndOfBuf)
 		{

--- a/src/ocpp/ppInclude.cpp
+++ b/src/ocpp/ppInclude.cpp
@@ -61,7 +61,7 @@ bool ppInclude::CheckInclude(kw token, const std::string& args)
 		std::string name = ParseName(line1, specifiedAsSystem);
 		int dirs_traversed = 0; // this is needed to get #include_next working correctly, the __has_include versions of this don't need to actually keep track tho cuz they don't actually include
 		name = FindFile(specifiedAsSystem, name, false, dirs_traversed);
-		pushFile(name, line1, dirs_traversed + 1);
+		pushFile(name, line1, false, dirs_traversed + 1);
 		return true;
 	}
 	else if (token == kw::INCLUDE_NEXT)
@@ -74,7 +74,7 @@ bool ppInclude::CheckInclude(kw token, const std::string& args)
 		std::string name = ParseName(line1, specifiedAsSystem);
 		int dirs_skipped = 0;
 		name = FindFile(false, name, true, dirs_skipped);
-		pushFile(name, line1, dirs_skipped + 1);
+		pushFile(name, line1, true, dirs_skipped + 1);
 		return true;
 	}
 	return false;
@@ -116,13 +116,20 @@ bool ppInclude::CheckLine(kw token, const std::string& args)
 	}
 	return false;
 }
-void ppInclude::pushFile(const std::string& name, const std::string& errname, int dirs_traversed)
+void ppInclude::pushFile(const std::string& name, const std::string& errname, bool include_next, int dirs_traversed)
 {
 	// gotta do the test first to get the error correct if it isn't there
 	std::fstream in(name, std::ios::in);
 	if (!piper.HasPipe() && name[0] != '-' && !in.is_open())
 	{
-		Errors::Error(std::string("Could not open ") + errname + " for input");
+		if (!include_next)
+		{
+			Errors::Error(std::string("Could not open ") + errname + " for input");
+		}
+		else
+		{
+			Errors::Error(std::string("Could not open using #include_next ") + errname + " for input");
+		}
 	}
 	else
 	{

--- a/src/ocpp/ppInclude.h
+++ b/src/ocpp/ppInclude.h
@@ -65,7 +65,7 @@ public:
 		define = Define;
 		ctx = Ctx;
 		expr.SetParams(define);
-		pushFile(Name, Name);
+		pushFile(Name, Name, false);
 	}
 	bool Check(kw token, const std::string& line);
 	bool IsOpen() const
@@ -112,7 +112,7 @@ public:
 			return current->GetIndex();
 		return false;
 	}
-	void IncludeFile(const std::string& name) { pushFile(name, name); }
+	void IncludeFile(const std::string& name) { pushFile(name, name, false); }
 	void SetInProc(const std::string& name) { inProc = name; }
 	void Mark() { current->Mark(); }
 	void Drop() { current->Drop(); }
@@ -135,7 +135,7 @@ protected:
 	void StripAsmComment(std::string& line);
 	bool CheckInclude(kw token, const std::string& line);
 	bool CheckLine(kw token, const std::string& line);
-	void pushFile(const std::string& name, const std::string& errname, int dirs_traversed = 0);
+	void pushFile(const std::string& name, const std::string& errname, bool include_next, int dirs_traversed = 0);
 	bool popFile();
 	std::string ParseName(const std::string& args, bool& specifiedAsSystem);
 	// Put a throwaway value in dirs_skipped here unless you need to use it for #include_next shenanigans with pushFile


### PR DESCRIPTION
This fixes an issue with #include_next specifically with the ability to
include files that are in the same directory as the compiled one, this
is an error and is solved by simply checking if the path has been
completed on its go through, if it has been, return that we have an
error (empty filename). I was originally going to do this
overcomplicated error handling mechanism when I realized that:

1. It was way too complex for anything useful

2. It was far too much effort

3. It would not change the root of the problem, that which the original
   compiled directory was somehow being included despite #include_next
   by definition skipping it.

These 8 lines fix points 1, 2, and 3.

I tested this against the q.bat setup given as a dump from the last PR, the error message should probably propagate the information that it failed on an #include_next, but that's also a far more complex thing than this solution is, unless you want me to fix that in this PR, of which I might have to do the modifications I was originally doing.