### PR TITLE
Fix bug by skipping files properly

### DIFF
--- a/src/ocpp/ppInclude.cpp
+++ b/src/ocpp/ppInclude.cpp
@@ -306,6 +306,7 @@ std::string ppInclude::SrchPath(bool system, const std::string& name, const std:
 		else
 		{
 			path = RetrievePath(buf, path);
+			filesSkipped++;
 		}
 		if (path == nullptr && skipUntilDepth && (buf != nullptr && *buf == '\0'))
 		{

--- a/src/ocpp/ppInclude.cpp
+++ b/src/ocpp/ppInclude.cpp
@@ -253,7 +253,7 @@ std::string ppInclude::FindFile(bool specifiedAsSystem, const std::string& name,
 		{
 			rv = rv.substr(0, npos);
 			rv = SrchPath(false, name, rv, skipFirst, throwaway);
-			include_files_skipped = current->getDirsTravelled();
+			//include_files_skipped = current->getDirsTravelled();
 		}
 		else
 		{
@@ -334,7 +334,7 @@ std::string ppInclude::SrchPath(bool system, const std::string& name, const std:
 		{
 			if (filesSkipped > 0) // we lie to ourselves about how many files we skip while searching so that we go past the current file's directory
 			{
-				filesSkipped--;
+				//filesSkipped--;
 			}
 			if (searchPath == ".")  // clean up for current directory searches
 				memmove(buf, buf + 2, strlen(buf) + 1);


### PR DESCRIPTION
This fixes the bug that reopened #523 this should not be responsible for the:

```
occparse Version 6.0.45.1 Copyright (C) LADSoft 2006-2020
Error( 11)    C:\OrangeC\include\__config(513):  Syntax error: ) expected
Error( 11)    C:\OrangeC\include\__config(517):  Syntax error: ) expected
Error( 11)    C:\OrangeC\include\__config(521):  Syntax error: ) expected
Error( 11)    C:\OrangeC\include\__config(531):  Syntax error: ) expected
Error( 11)    C:\OrangeC\include\__config(535):  Syntax error: ) expected
Error( 11)    C:\OrangeC\include\__config(536):  Syntax error: ) expected
Error( 11)    C:\OrangeC\include\__config(543):  Syntax error: ) expected
Error( 11)    C:\OrangeC\include\__config(547):  Syntax error: ) expected
Error( 11)    C:\OrangeC\include\__config(551):  Syntax error: ) expected
Error( 11)    C:\OrangeC\include\__config(564):  Syntax error: ) expected
Error( 11)    C:\OrangeC\include\__config(568):  Syntax error: ) expected
Error( 11)    C:\OrangeC\include\__config(572):  Syntax error: ) expected
Error( 11)    C:\OrangeC\include\__config(1251):  Syntax error: ) expected
Error( 11)    C:\OrangeC\include\__config(1458):  Syntax error: ) expected
Error( 11)    C:\OrangeC\src\clibs\cmath\cgamma.c(126):  Syntax error: ; expected
Error(437)    C:\OrangeC\src\clibs\cmath\cgamma.c(128):  Invalid use of type 'int'
Error(437)    C:\OrangeC\src\clibs\cmath\cgamma.c(155):  Invalid use of type 'int'
Error( 11)    C:\OrangeC\src\clibs\cmath\cgamma.c(239):  Syntax error: ; expected
Error(437)    C:\OrangeC\src\clibs\cmath\cgamma.c(241):  Invalid use of type 'int'
19 Errors

```

bugs that appeared immediately afterward, I have no idea what these are anyways and I'm currently too tired to look at the code to trawl through a section of the compiler I sadly have become unfamiliar with over the past 6 months.