### PR TITLE
Fix all problems I know how to fix

### DIFF
--- a/src/ocpp/ppInclude.cpp
+++ b/src/ocpp/ppInclude.cpp
@@ -254,7 +254,10 @@ std::string ppInclude::FindFile(bool specifiedAsSystem, const std::string& name,
 		{
 			rv = rv.substr(0, npos);
 			rv = SrchPath(false, name, rv, skipFirst, throwaway);
-			include_files_skipped = current->getDirsTravelled();
+			if (!rv.empty())
+			{
+				include_files_skipped = current->getDirsTravelled();
+			}
 		}
 		else
 		{
@@ -265,7 +268,12 @@ std::string ppInclude::FindFile(bool specifiedAsSystem, const std::string& name,
 	// #include_next does not search this, skip it.
 	if (rv.empty() && !skipFirst)
 	{
-		rv = SrchPath(false, name, ".", skipFirst, include_files_skipped);
+		int throwaway = 0;
+		rv = SrchPath(false, name, ".", skipFirst, throwaway);
+		if (!rv.empty())
+		{
+			include_files_skipped = current->getDirsTravelled();
+		}
 	}
 	// if not there search on user search path
 	// #include_next basically runs through only these two, and maybe the first, if the 2nd here doesn't run, but it's already an inconsistent feature so
@@ -290,9 +298,9 @@ std::string ppInclude::SrchPath(bool system, const std::string& name, const std:
 	do
 	{
 		bool reachedEndOfBuf = false;
-		if (skipUntilDepth && (filesSkipped < totalNumberofSkipsNeeded))
+		if (skipUntilDepth && (filesSkipped <= totalNumberofSkipsNeeded))
 		{
-			while (filesSkipped < totalNumberofSkipsNeeded)
+			while (filesSkipped <= totalNumberofSkipsNeeded)
 			{
 				// Prevent nullptr exceptions and clear out the value of buf
 				// TODO: find a fix that's faster than this, if compiled with any compiler that has vectorization this should be faster than strlen

--- a/src/ocpp/ppInclude.cpp
+++ b/src/ocpp/ppInclude.cpp
@@ -60,6 +60,7 @@ bool ppInclude::CheckInclude(kw token, const std::string& args)
 			define->Process(line1);
 		bool specifiedAsSystem = false;
 		std::string name = ParseName(line1, specifiedAsSystem);
+		const char* breakpoint = name.c_str();
 		int dirs_traversed = 0; // this is needed to get #include_next working correctly, the __has_include versions of this don't need to actually keep track tho cuz they don't actually include
 		name = FindFile(specifiedAsSystem, name, false, dirs_traversed);
 		pushFile(name, line1, false, dirs_traversed);
@@ -253,7 +254,7 @@ std::string ppInclude::FindFile(bool specifiedAsSystem, const std::string& name,
 		{
 			rv = rv.substr(0, npos);
 			rv = SrchPath(false, name, rv, skipFirst, throwaway);
-			//include_files_skipped = current->getDirsTravelled();
+			include_files_skipped = current->getDirsTravelled();
 		}
 		else
 		{
@@ -289,9 +290,9 @@ std::string ppInclude::SrchPath(bool system, const std::string& name, const std:
 	do
 	{
 		bool reachedEndOfBuf = false;
-		if (skipUntilDepth && (filesSkipped < totalNumberofSkipsNeeded + 1))
+		if (skipUntilDepth && (filesSkipped < totalNumberofSkipsNeeded))
 		{
-			while (filesSkipped < totalNumberofSkipsNeeded + 1)
+			while (filesSkipped < totalNumberofSkipsNeeded)
 			{
 				// Prevent nullptr exceptions and clear out the value of buf
 				// TODO: find a fix that's faster than this, if compiled with any compiler that has vectorization this should be faster than strlen


### PR DESCRIPTION
The current issue that I cannot fix is the searching from the path of
the last included file, because with files that go into deeper
directories, this functionality is 100% broken, not that it probably
wouldn't cause problems down the line, due to it skipping possibly
necessary imports and seriously messes with anything related to
\#include_next or any functionality that decides to respect the ordering
of include paths, which this absolutely, totally, completely, destroys.

Removing this functionality is also a breaking change, so if we're going
to do this, I would recommend doing this now, when it rears the problems
in implementing #include_next and anything that relies on system files.


DO NOT PULL THIS PR UNTIL COMPLETELY TESTED!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! <---------------------------------

This PR can work after the bug I mentioned is fixed, the functionality I'm talking about starts on line 246 of the ppInclude.cpp file, and goes to line 263 of the same file. Until this functionality is either fixed or removed entirely, this PR *WILL NOT WORK*, and I don't generally like to make these decisions, because this is a 100% breaking change, I just recommend that to prevent future headaches, removing this functionality in its entirety be considered. GCC does do the "check current directory" scheme for user includes, but we do this too, but this is not the same as the file path of the last included file.

TL;DR: Please consider this breaking change before we go further on this PR.