### PR TITLE
fixed typo in structur.h

### DIFF
--- a/src/clibs/platform/win32/wininc/win32/structur.h
+++ b/src/clibs/platform/win32/wininc/win32/structur.h
@@ -4634,7 +4634,7 @@ typedef struct _UNWIND_HISTORY_TABLE {
 #define RTL_RUN_ONCE_CTX_RESERVED_BITS 2
 typedef union _RTL_RUN_ONCE {       
     PVOID Ptr;                      
-} RTL_RUN_ONCE, *PRTL_RUN_ONCE, INIT_ONCE, *PINIT_ONCE, *LPINIT_OCNE;     
+} RTL_RUN_ONCE, *PRTL_RUN_ONCE, INIT_ONCE, *PINIT_ONCE, *LPINIT_ONCE;     
 
 typedef struct _RTL_SRWLOCK {                            
         PVOID Ptr;                                       


### PR DESCRIPTION
See discussion in a5e60ed2fbc6764986e60846346933fd0175fb03.