### PR TITLE
Fix stdint.h and use an unordered_map with custom hasher for beintrins

### DIFF
--- a/src/clibs/stdinc/stdint.h
+++ b/src/clibs/stdinc/stdint.h
@@ -63,7 +63,7 @@ typedef unsigned uint_least32_t;
 typedef int int_fast32_t;
 typedef unsigned uint_fast32_t;
 
-#if __STDC_VERSION__ >= 199901L
+#if __STDC_VERSION__ >= 199901L || defined(__cplusplus)
 typedef long long int64_t;
 typedef unsigned long long uint64_t;
 typedef long long int_least64_t;
@@ -86,7 +86,7 @@ typedef int64_t intmax_t;
 typedef uint64_t uintmax_t;
 
 #endif
-#if !defined(__cplusplus) || defined(__STDC_LIMIT_MACROS)
+#if defined(__STDC_LIMIT_MACROS) || defined(__cplusplus)
 
 #    define INT8_MIN -128
 #    define INT8_MAX 127
@@ -155,7 +155,7 @@ typedef uint64_t uintmax_t;
 
 #endif
 
-#if !defined(__cplusplus) || _LIBCPP_VERSION >= 10000 || defined(__STDC_CONSTANT_MACROS)
+#if defined(__STDC_CONSTANT_MACROS) || defined(__cplusplus)
 
 #    define INT8_C(x) ((int_least8_t)x)
 #    define UINT8_C(x) ((uint_least8_t)x##U)


### PR DESCRIPTION
This *SHOULD* make the beintrins check a little more organized and may or may not take less time overall. Technically this is a O(2n) function, but it should still be faster than the O(n * m) function we had before. 

Also this fixes everything for C and C++ stdint, maybe unless we need to unrestrict stuff after C99 for the __STDC_LIMIT_MACROS and __STDC_CONSTANT_MACROS stuff, however this does allow the constructs to compile in C++ and I haven't had time to check 3 different standards to see the exacts necessary...