### PR TITLE
omake long-options compatibility to GNU make

### DIFF
--- a/src/occ/beIntrins.cpp
+++ b/src/occ/beIntrins.cpp
@@ -54,6 +54,14 @@ class fnv1a_class
     }
 
 };
+class str_eql
+{
+    public:
+    bool operator()(const char* a, const char* b) const
+    {
+        return !strcmp(a, b);
+    }
+};
 using fnv1a64 = fnv1a_class<uint64_t, UINT64_C(1099511628211), UINT64_C(14695981039346656037)>;
 typedef bool (*BUILTIN)();
 
@@ -65,7 +73,7 @@ typedef struct builtins
 #define PROTO(PROT, NAME, FUNC) bool FUNC();
 #include "beIntrinsicProtos.h"
 #define PROTO(PROT, NAME, FUNC) {#NAME, FUNC},
-std::unordered_map<const char*, BUILTIN, fnv1a64> builtin_map = {
+std::unordered_map<const char*, BUILTIN, fnv1a64, str_eql> builtin_map = {
 #include "beIntrinsicProtos.h"
 };
 
@@ -238,7 +246,6 @@ bool handleBSWAP64()
 bool BackendIntrinsic(Optimizer::QUAD* q)
 {
     const char* name = q->dc.left->offset->sp->name;
-
     auto thing = builtin_map.find(name);
     if(thing != builtin_map.end())
     {

--- a/src/omake/MakeMain.cpp
+++ b/src/omake/MakeMain.cpp
@@ -41,27 +41,27 @@
 #include <algorithm>
 
 CmdSwitchParser MakeMain::switchParser;
-CmdSwitchCombineString MakeMain::specifiedFiles(switchParser, 'f', ' ');
+CmdSwitchCombineString MakeMain::specifiedFiles(switchParser, 'f', ' ', "file");
 CmdSwitchBool MakeMain::displayOnly(switchParser, 'n', false, "dry-run");
-CmdSwitchBool MakeMain::touch(switchParser, 't');
-CmdSwitchBool MakeMain::query(switchParser, 'q');
+CmdSwitchBool MakeMain::touch(switchParser, 't', false, "touch");
+CmdSwitchBool MakeMain::query(switchParser, 'q', false, "question");
 CmdSwitchBool MakeMain::keepGoing(switchParser, 'k', false, "keep-going");
-CmdSwitchBool MakeMain::ignoreErrors(switchParser, 'i');
+CmdSwitchBool MakeMain::ignoreErrors(switchParser, 'i', false, "ignore-errors");
 CmdSwitchDefine MakeMain::defines(switchParser, 'D', "eval");
-CmdSwitchBool MakeMain::rebuild(switchParser, 'B');
-CmdSwitchCombineString MakeMain::newFiles(switchParser, 'W', ' ');
-CmdSwitchCombineString MakeMain::oldFiles(switchParser, 'o', ' ');
-CmdSwitchCombineString MakeMain::dir(switchParser, 'C', '+');
+CmdSwitchBool MakeMain::rebuild(switchParser, 'B', false, "always-make");
+CmdSwitchCombineString MakeMain::newFiles(switchParser, 'W', ' ', "assume-new");
+CmdSwitchCombineString MakeMain::oldFiles(switchParser, 'o', ' ', "assume-old");
+CmdSwitchCombineString MakeMain::dir(switchParser, 'C', '+', "directory");
 CmdSwitchBool MakeMain::debug(switchParser, 'd');  // not implemented
-CmdSwitchBool MakeMain::environOverride(switchParser, 'e');
+CmdSwitchBool MakeMain::environOverride(switchParser, 'e', false, "environment-overrides");
 CmdSwitchBool MakeMain::help(switchParser, 'h');
 CmdSwitchBool MakeMain::help2(switchParser, '?', false, "help");
-CmdSwitchCombineString MakeMain::includes(switchParser, 'I', ';');
-CmdSwitchBool MakeMain::showDatabase(switchParser, 'p');
-CmdSwitchBool MakeMain::noBuiltinRules(switchParser, 'r');
-CmdSwitchBool MakeMain::noBuiltinVars(switchParser, 'R');
-CmdSwitchBool MakeMain::silent(switchParser, 's');
-CmdSwitchBool MakeMain::cancelKeep(switchParser, 'S');
+CmdSwitchCombineString MakeMain::includes(switchParser, 'I', ';', "include-dir");
+CmdSwitchBool MakeMain::showDatabase(switchParser, 'p', false, "print-data-base");
+CmdSwitchBool MakeMain::noBuiltinRules(switchParser, 'r', false, "no-builtin-rules");
+CmdSwitchBool MakeMain::noBuiltinVars(switchParser, 'R', false, "no-builtin-variables");
+CmdSwitchBool MakeMain::silent(switchParser, 's', false, "quiet");
+CmdSwitchBool MakeMain::cancelKeep(switchParser, 'S', false, "no-keep-going");
 CmdSwitchBool MakeMain::printDir(switchParser, 'w', false, "print-directory");
 CmdSwitchBool MakeMain::warnUndef(switchParser, 'u');
 CmdSwitchBool MakeMain::treeBuild(switchParser, 'T');


### PR DESCRIPTION
follow up to 9542dfe15bf22eab72a2c8134c442381f075a1e5, using https://www.gnu.org/software/make/manual/make.html#Options-Summary as template

fair warning:

* this was a browser-only edit, not tested at all
* to improve the compatiblity to GNU make and other make implementations the longopt argument needs to be an _array_ of strings, not a single array; you may consider this as a feature request and could add the additional long-options GNU make knows about (often from other make implementations) from the template [should this be a new FR?]