### PR TITLE
omake long-options compatibility to GNU make

### DIFF
--- a/src/omake/MakeMain.cpp
+++ b/src/omake/MakeMain.cpp
@@ -41,27 +41,27 @@
 #include <algorithm>
 
 CmdSwitchParser MakeMain::switchParser;
-CmdSwitchCombineString MakeMain::specifiedFiles(switchParser, 'f', ' ');
+CmdSwitchCombineString MakeMain::specifiedFiles(switchParser, 'f', ' ', "file");
 CmdSwitchBool MakeMain::displayOnly(switchParser, 'n', false, "dry-run");
-CmdSwitchBool MakeMain::touch(switchParser, 't');
-CmdSwitchBool MakeMain::query(switchParser, 'q');
+CmdSwitchBool MakeMain::touch(switchParser, 't', false, "touch");
+CmdSwitchBool MakeMain::query(switchParser, 'q', false, "question");
 CmdSwitchBool MakeMain::keepGoing(switchParser, 'k', false, "keep-going");
-CmdSwitchBool MakeMain::ignoreErrors(switchParser, 'i');
+CmdSwitchBool MakeMain::ignoreErrors(switchParser, 'i', false, "ignore-errors");
 CmdSwitchDefine MakeMain::defines(switchParser, 'D', "eval");
-CmdSwitchBool MakeMain::rebuild(switchParser, 'B');
-CmdSwitchCombineString MakeMain::newFiles(switchParser, 'W', ' ');
-CmdSwitchCombineString MakeMain::oldFiles(switchParser, 'o', ' ');
-CmdSwitchCombineString MakeMain::dir(switchParser, 'C', '+');
+CmdSwitchBool MakeMain::rebuild(switchParser, 'B', false, "always-make");
+CmdSwitchCombineString MakeMain::newFiles(switchParser, 'W', ' ', "assume-new");
+CmdSwitchCombineString MakeMain::oldFiles(switchParser, 'o', ' ', "assume-old");
+CmdSwitchCombineString MakeMain::dir(switchParser, 'C', '+', "directory");
 CmdSwitchBool MakeMain::debug(switchParser, 'd');  // not implemented
-CmdSwitchBool MakeMain::environOverride(switchParser, 'e');
+CmdSwitchBool MakeMain::environOverride(switchParser, 'e', false, "environment-overrides");
 CmdSwitchBool MakeMain::help(switchParser, 'h');
 CmdSwitchBool MakeMain::help2(switchParser, '?', false, "help");
-CmdSwitchCombineString MakeMain::includes(switchParser, 'I', ';');
-CmdSwitchBool MakeMain::showDatabase(switchParser, 'p');
-CmdSwitchBool MakeMain::noBuiltinRules(switchParser, 'r');
-CmdSwitchBool MakeMain::noBuiltinVars(switchParser, 'R');
-CmdSwitchBool MakeMain::silent(switchParser, 's');
-CmdSwitchBool MakeMain::cancelKeep(switchParser, 'S');
+CmdSwitchCombineString MakeMain::includes(switchParser, 'I', ';', "include-dir");
+CmdSwitchBool MakeMain::showDatabase(switchParser, 'p', false, "print-data-base");
+CmdSwitchBool MakeMain::noBuiltinRules(switchParser, 'r', false, "no-builtin-rules");
+CmdSwitchBool MakeMain::noBuiltinVars(switchParser, 'R', false, "no-builtin-variables");
+CmdSwitchBool MakeMain::silent(switchParser, 's', false, "quiet");
+CmdSwitchBool MakeMain::cancelKeep(switchParser, 'S', false, "no-keep-going");
 CmdSwitchBool MakeMain::printDir(switchParser, 'w', false, "print-directory");
 CmdSwitchBool MakeMain::warnUndef(switchParser, 'u');
 CmdSwitchBool MakeMain::treeBuild(switchParser, 'T');


### PR DESCRIPTION
follow up to 9542dfe, using https://www.gnu.org/software/make/manual/make.html#Options-Summary as template

fair warning:

* this was a browser-only edit, only tested by CI (compiles)
* to improve the compatibility to GNU make and other make implementations the longopt argument needs to be an _array_ of strings, not a single array; you may consider this as a feature request and could add the additional long-options GNU make knows about (often from other make implementations) from the template [should this be a new FR?]