### PR TITLE
Fix #651 [[noreturn]] should work on non-void functions

### DIFF
--- a/src/objlib/ObjIeee.h
+++ b/src/objlib/ObjIeee.h
@@ -206,18 +206,12 @@ class ObjIeeeBinary : public ObjIOBase
     bool ModuleEnd(const ObjByte* buffer, eParseType ParseType);
     bool ModuleAttributes(const ObjByte* buffer, eParseType ParseType);
     bool ModuleDate(const ObjByte* buffer, eParseType ParseType);
-#ifndef __ORANGEC__
-    [[noreturn]]  // Satisfy the analyzer for MSVC so it shuts up on a bunch of other functions, but because of errors from OrangeC
-                  // this actually doesn't work, and it needs to be bool here to satisfy a function thing...
-#endif
-                  bool
-                  ThrowSyntax(const ObjByte* buffer, eParseType ParseType)
+    [[noreturn]] bool ThrowSyntax(const ObjByte* buffer, eParseType ParseType)
     {
         (void)buffer;
         (void)ParseType;
         SyntaxError e(lineno);
         throw e;
-        return false;  // In case exceptions are disabled, return *SOMETHING*
     }
 
     bool Parse(const ObjByte* buffer, eParseType ParseType);
@@ -452,17 +446,12 @@ class ObjIeeeAscii : public ObjIOBase
     bool ModuleEnd(const char* buffer, eParseType ParseType);
     bool ModuleAttributes(const char* buffer, eParseType ParseType);
     bool ModuleDate(const char* buffer, eParseType ParseType);
-#ifndef __ORANGEC__
-    [[noreturn]]  // Same as above
-#endif
-    bool
-    ThrowSyntax(const char* buffer, eParseType ParseType)
+    [[noreturn]] bool ThrowSyntax(const char* buffer, eParseType ParseType)
     {
         (void)buffer;
         (void)ParseType;
         SyntaxError e(lineno);
         throw e;
-        return false;
     }
 
     bool Parse(const char* buffer, eParseType ParseType);

--- a/src/objlib/ObjIeeeBinaryRead.cpp
+++ b/src/objlib/ObjIeeeBinaryRead.cpp
@@ -223,7 +223,6 @@ bool ObjIeeeBinary::Parse(const ObjByte* buffer, eParseType ParseType)
                     return TypeName(buffer, ParseType);
                 default:
                     ThrowSyntax(buffer, eAll);
-                    return false;
             }
         case ecCO:
             return Comment(buffer, ParseType);
@@ -249,7 +248,6 @@ bool ObjIeeeBinary::Parse(const ObjByte* buffer, eParseType ParseType)
             return ModuleEnd(buffer, ParseType);
         default:
             ThrowSyntax(buffer, eAll);
-            return false;
     }
 }
 void ObjIeeeBinary::getline(ObjByte* buf, size_t size)

--- a/src/occparse/stmt.cpp
+++ b/src/occparse/stmt.cpp
@@ -3452,7 +3452,11 @@ LEXLIST* compound(LEXLIST* lex, SYMBOL* funcsp, BLOCKDATA* parent, bool first)
         basetype(funcsp->tp)->btp->type != bt_auto && !funcsp->sb->isConstructor)
     {
         if (funcsp->sb->attribs.inheritable.linkage3 == lk_noreturn)
-            error(ERR_NORETURN);
+        {
+            // explicitly do nothing, refer to https://github.com/LADSoft/OrangeC/issues/651 for more information
+            // Keeping this here prevents nonsensical errors such as "FUNCTION SHOULD RETURN VALUE!!!!" when a function is marked
+            // noreturn. Noreturn functions can have non-void return types in order for things to work such as in ObjIeee.h's ThrowSyntax functions
+        }
         else if (Optimizer::cparams.prm_c99 || Optimizer::cparams.prm_cplusplus)
         {
             if (!thunkmainret(funcsp, blockstmt, false))


### PR DESCRIPTION
Fixes #651 such that any [[noreturn]] type attribute works on non-void functions.

This was accomplished simply by removing the error statement when checking if a non-void function has the attribute.