### PR TITLE
Fix rare issue where oasm could be potentially generating incorrect code

### DIFF
--- a/src/oasm/AsmExpr.cpp
+++ b/src/oasm/AsmExpr.cpp
@@ -165,7 +165,7 @@ AsmExprNode* AsmExpr::Eval(AsmExprNode* n, int pc)
                     fv += xleft->fval;
                     break;
                 case (AsmExprNode::FVAL << 8) + AsmExprNode::FVAL:
-                    fv = xleft->FVAL + xright->FVAL;
+                    fv = xleft->fval + xright->fval;
                     rv = new AsmExprNode(fv);
                     break;
                 default:


### PR DESCRIPTION
I noticed this issue where xleft->FVAL + xright->FVAL were being pointed out to me by Visual Studio during an Analysis run, as it turns out the issue at hand is that the FVAL property can be accessed due to an enum being a part of the class. I checked to make sure no other instances of something like this was happening, and thankfully this is the only case.