### PR TITLE
Add fixes to improve many issues with current libcxx tests

### DIFF
--- a/src/clibs/cpp/libcxx/test/support/platform_support.h
+++ b/src/clibs/cpp/libcxx/test/support/platform_support.h
@@ -58,6 +58,7 @@
 #include <string>
 #if defined(_WIN32) || defined(__MINGW32__)
 #include <io.h> // _mktemp_s
+#include <fileapi.h>
 #else
 #include <unistd.h> // close
 #endif
@@ -73,7 +74,7 @@ extern "C" {
 inline
 std::string get_temp_file_name()
 {
-#if defined(__MINGW32__)
+#if defined(__MINGW32__) || defined(__ORANGEC__)
     char Path[MAX_PATH + 1];
     char FN[MAX_PATH + 1];
     do { } while (0 == GetTempPath(MAX_PATH+1, Path));

--- a/src/clibs/platform/win32/wininc/fileapi.h
+++ b/src/clibs/platform/win32/wininc/fileapi.h
@@ -1,0 +1,1 @@
+#include "windows.h"

--- a/src/clibs/stdinc/inttypes.h
+++ b/src/clibs/stdinc/inttypes.h
@@ -41,7 +41,7 @@
 #    include <stdint.h>
 #endif
 
-#if !defined(__cplusplus) || defined(__STDC_FORMAT_MACROS)
+#if defined(__cplusplus) || defined(__STDC_FORMAT_MACROS)
 
 #    define PRId8 "hhd"
 #    define PRIi8 "hhi"

--- a/src/occparse/c.h
+++ b/src/occparse/c.h
@@ -1158,7 +1158,7 @@ typedef struct _atomicData
     TYPE* tp;
 } ATOMICDATA;
 
-constexpr inline TYPE* basetype(TYPE* a) { auto x = a; return ((x) /*&& (x)->rootType*/ ? (x)->rootType : (x)); }
+constexpr inline TYPE* basetype(TYPE* a) { auto x = a; return ((x && x->rootType) ? (x)->rootType : (x)); }
 
 constexpr inline bool __isref(TYPE* x) { return (x)->type == bt_lref || (x)->type == bt_rref; }
 constexpr inline bool isref(TYPE* x)
@@ -1178,6 +1178,7 @@ constexpr inline bool isfunction(TYPE* x) { return (__isfunction(basetype(x))); 
 
 constexpr inline bool isfuncptr(TYPE* x) { return (ispointer(x) && basetype(x)->btp && isfunction(basetype(x)->btp)); }
 constexpr inline bool __isstructured(TYPE* x) { return ((x)->type == bt_class || (x)->type == bt_struct || (x)->type == bt_union); }
+
 constexpr inline bool isstructured(TYPE* x) { return (__isstructured(basetype(x))); }
 
 }  // namespace Parser

--- a/src/occparse/expr.cpp
+++ b/src/occparse/expr.cpp
@@ -7155,8 +7155,8 @@ static LEXLIST* expression_pm(LEXLIST* lex, SYMBOL* funcsp, TYPE* atp, TYPE** tp
         {
             if (isstructured(*tp) && basetype(tp1)->type == bt_memberptr)
             {
-                if ((*tp)->sp != basetype(tp1)->sp && (*tp)->sp->sb->mainsym != basetype(tp1)->sp &&
-                    (*tp)->sp != basetype(tp1)->sp->sb->mainsym)
+                if (basetype(*tp)->sp != basetype(tp1)->sp && basetype(*tp)->sp->sb->mainsym != basetype(tp1)->sp &&
+                    basetype(*tp)->sp != basetype(tp1)->sp->sb->mainsym)
                 {
                     if (classRefCount(basetype(tp1)->sp, (*tp)->sp) != 1)
                     {
@@ -7175,7 +7175,7 @@ static LEXLIST* expression_pm(LEXLIST* lex, SYMBOL* funcsp, TYPE* atp, TYPE** tp
                 if (isfunction(basetype(tp1)->btp))
                 {
                     FUNCTIONCALL* funcparams = Allocate<FUNCTIONCALL>();
-                    if ((*tp)->sp->sb->vbaseEntries)
+                    if ((basetype(*tp))->sp->sb->vbaseEntries)
                     {
                         EXPRESSION* ec = exprNode(en_add, exp1, intNode(en_c_i, getSize(bt_pointer) + getSize(bt_int)));
                         EXPRESSION* ec1;


### PR DESCRIPTION
The fixes here are for a lot of tests failing not having correct support
in creating a temporary file name, tests for inttypes not having all of
the correct integer formats for C++, and basetypes not being checked
when searching for candidates' symbol pointers, causing crashes when
types are const or volatile.

I'm also working on an issue where noexcept specifiers on specific constructors aren't being applied correctly and am trying to track down in-code where that can be happening but due to the sheer number of places debugging that will probably take a few days.