### PR TITLE
Add beginning stages of C2x support

### DIFF
--- a/src/clibs/platform/win32/lscrtl/makefile
+++ b/src/clibs/platform/win32/lscrtl/makefile
@@ -64,7 +64,8 @@ DLLOBJS = $(shell dir $(B) $(CLIBOBJECT)\\*.o)
 	$(CC) /c /C-E $(CFLAGS) $(STDINCLUDE) -o$@ $^
 
 $(RCFILE).res: $(RCFILE).rc ..\..\..\..\version.h
-	orc -i..\wininc $(RCFILE).rc
+	echo $(CURDIR)
+	orc -i..\inc $(RCFILE).rc
 
 #DISTRIBUTE:
 #	$(ZIP) -porangec a $(DISTADDON)\lscrtl $(LSCRTLOBJECT)\*.*

--- a/src/occopt/beinterfdefs.h
+++ b/src/occopt/beinterfdefs.h
@@ -58,6 +58,7 @@ typedef struct
     bool prm_cmangle;            /* add underscore to names */
     bool prm_c99;                /* C99 mode */
     bool prm_c1x;                /* C1x mode */
+    bool prm_c2x;                /* C2x mode */
     bool prm_cplusplus;          /* C++ mode */
     bool prm_xcept;              /* generate RTTI in C++ mode */
     bool prm_icdfile;            /* dump intermediate code peep list to file */

--- a/src/occparse/c.h
+++ b/src/occparse/c.h
@@ -363,7 +363,7 @@ typedef struct expr
     int isfunc : 1;
     int dest : 1;  // for thisref
     int noexprerr : 1;
-    int init : 1;  // for no replacement by a constexpr array
+    int init : 1;       // for no replacement by a constexpr array
     int preincdec : 1;  //  an assignment which is the 'pre' form of autoinc
     int keepZero : 1;
     int paramArray : 1;
@@ -446,7 +446,7 @@ typedef struct typ
     struct typ* etype;            /* type of size field  when size isn't constant */
     int vlaindex;                 /* index into the vararray */
     EXPRESSION* templateDeclType; /* for bt_templatedecltype, used in templates */
-    struct typ* typedefType;            /* The typedef which describes this type */
+    struct typ* typedefType;      /* The typedef which describes this type */
 } TYPE;
 
 typedef struct stmt
@@ -760,7 +760,7 @@ typedef struct sym
         Optimizer::LIST* friends;
         attributes attribs;
         /* Type declarations */
-    } * sb;
+    }* sb;
 } SYMBOL;
 
 typedef struct __lambda
@@ -1005,7 +1005,7 @@ struct balance
     {
         KW_NONE = 0, KW_CPLUSPLUS = 1, KW_INLINEASM = 2, KW_NONANSI = 4, KW_C99 = 8,
         KW_C1X = 16, KW_ASSEMBLER = 32, KW_MSIL = 64,
-        KW_386 = 128, KW_68K = 256, KW_ALL = 0x40000000
+        KW_386 = 128, KW_68K = 256, KW_C2X = 512, KW_ALL = 0x40000000
     };
 // clang-format on
 // clang-format off
@@ -1166,7 +1166,12 @@ typedef struct _atomicData
     TYPE* tp;
 } ATOMICDATA;
 
-constexpr inline TYPE* basetype(TYPE* a) { if (a) a = a->rootType; return a; }
+constexpr inline TYPE* basetype(TYPE* a)
+{
+    if (a)
+        a = a->rootType;
+    return a;
+}
 
 constexpr inline bool __isref(TYPE* x) { return (x)->type == bt_lref || (x)->type == bt_rref; }
 constexpr inline bool isref(TYPE* x)

--- a/src/occparse/lex.cpp
+++ b/src/occparse/lex.cpp
@@ -46,7 +46,7 @@
 #include "expr.h"
 #include "template.h"
 
-//#define TESTANNOTATE
+// #define TESTANNOTATE
 
 namespace Parser
 {
@@ -140,8 +140,8 @@ KEYWORD keywords[] = {
     */
     {"_Alignas", 8, kw_alignas, KW_C1X, TT_CONTROL},
     {"_Alignof", 8, kw_alignof, KW_C1X, TT_UNARY | TT_OPERATOR},
-    {"_Atomic", 7, kw_atomic, KW_C1X | KW_CPLUSPLUS, TT_POINTERQUAL | TT_TYPEQUAL | TT_BASETYPE},
-    {"_Bool", 5, kw_bool, 0, TT_BASETYPE | TT_BOOL},
+    {"_Atomic", 7, kw_atomic, KW_C1X | KW_CPLUSPLUS | KW_C2X, TT_POINTERQUAL | TT_TYPEQUAL | TT_BASETYPE},
+    {"_Bool", 5, kw_bool, KW_C99 | KW_C1X, TT_BASETYPE | TT_BOOL},
     {"_CR0", 4, kw_cr0, KW_NONANSI | KW_386, TT_VAR},
     {"_CR1", 4, kw_cr1, KW_NONANSI | KW_386, TT_VAR},
     {"_CR2", 4, kw_cr2, KW_NONANSI | KW_386, TT_VAR},
@@ -300,15 +300,15 @@ KEYWORD keywords[] = {
     {"_seg", 4, kw__seg, KW_NONANSI | KW_ALL, TT_TYPEQUAL | TT_POINTERQUAL},
     {"_stdcall", 8, kw__stdcall, KW_NONANSI | KW_ALL, TT_LINKAGE},
     {"_trap", 5, kw__trap, KW_NONANSI | KW_ALL, TT_OPERATOR | TT_UNARY},
-    {"alignas", 7, kw_alignas, KW_CPLUSPLUS, TT_CONTROL},
-    {"alignof", 7, kw_alignof, KW_CPLUSPLUS, TT_UNARY | TT_OPERATOR},
+    {"alignas", 7, kw_alignas, KW_CPLUSPLUS | KW_C2X, TT_CONTROL},
+    {"alignof", 7, kw_alignof, KW_CPLUSPLUS | KW_C2X, TT_UNARY | TT_OPERATOR},
     {"and", 3, land, KW_CPLUSPLUS, TT_BINARY | TT_OPERATOR},
     {"and_eq", 6, asand, KW_CPLUSPLUS, TT_ASSIGN | TT_OPERATOR},
     {"asm", 3, kw_asm, KW_NONANSI | KW_ALL, TT_CONTROL},
     {"auto", 4, kw_auto, 0, TT_STORAGE_CLASS},
     {"bitand", 6, andx, KW_CPLUSPLUS, TT_BINARY | TT_OPERATOR},
     {"bitor", 5, orx, KW_CPLUSPLUS, TT_BINARY | TT_OPERATOR},
-    {"bool", 4, kw_bool, KW_CPLUSPLUS, TT_BASETYPE | TT_BOOL},
+    {"bool", 4, kw_bool, KW_CPLUSPLUS | KW_C2X, TT_BASETYPE | TT_BOOL},
     {"break", 5, kw_break, 0, TT_CONTROL},
     {"case", 4, kw_case, 0, TT_CONTROL | TT_SWITCH},
     {"catch", 5, kw_catch, KW_CPLUSPLUS, TT_CONTROL},
@@ -333,7 +333,7 @@ KEYWORD keywords[] = {
     {"explicit", 8, kw_explicit, KW_CPLUSPLUS, TT_STORAGE_CLASS},
     {"export", 6, kw_export, KW_CPLUSPLUS, TT_UNKNOWN},
     {"extern", 6, kw_extern, KW_ASSEMBLER, TT_STORAGE_CLASS},
-    {"false", 5, kw_false, KW_CPLUSPLUS, TT_VAR},
+    {"false", 5, kw_false, KW_CPLUSPLUS | KW_C2X, TT_VAR},
     //	{ "far", 3,  kw__far, KW_NONANSI | KW_ALL, TT_POINTERQUAL | TT_TYPEQUAL},
     {"float", 5, kw_float, 0, TT_BASETYPE | TT_FLOAT},
     {"for", 3, kw_for, 0, TT_CONTROL},
@@ -351,7 +351,7 @@ KEYWORD keywords[] = {
     {"noexcept", 8, kw_noexcept, KW_CPLUSPLUS, TT_CONTROL},
     {"not", 3, notx, KW_CPLUSPLUS, TT_UNARY | TT_OPERATOR},
     {"not_eq", 6, neq, KW_CPLUSPLUS, TT_RELATION | TT_EQUALITY},
-    {"nullptr", 7, kw_nullptr, KW_CPLUSPLUS, TT_VAR},
+    {"nullptr", 7, kw_nullptr, KW_CPLUSPLUS | KW_C2X, TT_VAR},
     {"operator", 8, kw_operator, KW_CPLUSPLUS, TT_OPERATOR},
     {"or", 2, lor, KW_CPLUSPLUS, TT_BINARY | TT_OPERATOR},
     {"or_eq", 5, asor, KW_CPLUSPLUS, TT_ASSIGN | TT_OPERATOR},
@@ -374,7 +374,7 @@ KEYWORD keywords[] = {
     {"this", 4, kw_this, KW_CPLUSPLUS, TT_VAR},
     {"thread_local", 12, kw_thread_local, KW_CPLUSPLUS, TT_LINKAGE},
     {"throw", 5, kw_throw, KW_CPLUSPLUS, TT_OPERATOR | TT_UNARY},
-    {"true", 4, kw_true, KW_CPLUSPLUS, TT_VAR},
+    {"true", 4, kw_true, KW_CPLUSPLUS | KW_C2X, TT_VAR},
     {"try", 3, kw_try, KW_CPLUSPLUS, TT_CONTROL},
     {"typedef", 7, kw_typedef, 0, TT_BASETYPE | TT_TYPEDEF | TT_STORAGE_CLASS},
     {"typeid", 6, kw_typeid, KW_CPLUSPLUS, TT_UNKNOWN},
@@ -466,7 +466,8 @@ static bool kwmatches(KEYWORD* kw)
         return !!(kw->matchFlags & KW_ASSEMBLER);
     else if (!kw->matchFlags || kw->matchFlags == KW_ASSEMBLER)
         return true;
-    else if (((kw->matchFlags & KW_CPLUSPLUS) && Optimizer::cparams.prm_cplusplus) || (kw->matchFlags & (KW_C99 | KW_C1X)) ||
+    else if (((kw->matchFlags & KW_CPLUSPLUS) && Optimizer::cparams.prm_cplusplus) ||
+             (kw->matchFlags & (KW_C99 | KW_C1X | KW_C2X)) ||
              ((kw->matchFlags & KW_MSIL) && (Optimizer::architecture == ARCHITECTURE_MSIL) &&
               Optimizer::cparams.msilAllowExtensions) ||
              ((kw->matchFlags & (KW_NONANSI | KW_INLINEASM)) && !Optimizer::cparams.prm_ansi))
@@ -512,6 +513,8 @@ KEYWORD* searchkw(const unsigned char** p)
                     if (Optimizer::cparams.prm_c99 && (kw->matchFlags & KW_C99))
                         count++;
                     if (Optimizer::cparams.prm_c1x && (kw->matchFlags & KW_C1X))
+                        count++;
+                    if (Optimizer::cparams.prm_c2x && (kw->matchFlags & KW_C2X))
                         count++;
                     if (Optimizer::cparams.prm_cplusplus && (kw->matchFlags & KW_CPLUSPLUS))
                         count++;

--- a/src/occparse/libcxx.cpp
+++ b/src/occparse/libcxx.cpp
@@ -118,7 +118,7 @@ void libcxx_builtins(void)
         preProcessor->Define("__has_cxx_access_control_sfinae", "0");
         preProcessor->Define("__has_cxx_alias_templates", "1");
         preProcessor->Define("__has_cxx_alignas", "1");
-        preProcessor->Define("__has_cxx_atomic", "0");
+        preProcessor->Define("__has_cxx_atomic", "1");
         preProcessor->Define("__has_cxx_attributes", "1");
         preProcessor->Define("__has_cxx_auto_type", "1");
         preProcessor->Define("__has_cxx_constexpr", "1");

--- a/src/occparse/occparse.cpp
+++ b/src/occparse/occparse.cpp
@@ -139,6 +139,7 @@ Optimizer::COMPILER_PARAMS cparams_default = {
     true,  /* char prm_cmangle;*/
     true,  /* char prm_c99;*/
     true,  /* char prm_c1x;*/
+    false, /* char prm_c2x; */
     false, /* char prm_cplusplus;*/
     true,  /* char prm_xcept;*/
     false, /* char prm_icdfile;*/

--- a/src/occparse/osutil.cpp
+++ b/src/occparse/osutil.cpp
@@ -79,6 +79,7 @@ CmdSwitchParser switchParser;
 CmdSwitchBool prm_c89(switchParser, '8');
 CmdSwitchBool prm_c99(switchParser, '9');
 CmdSwitchBool prm_c11(switchParser, '1');
+CmdSwitchBool prm_c2x(switchParser, '2');
 CmdSwitchBool prm_ansi(switchParser, 'A');
 CmdSwitchBool prm_errfile(switchParser, 'e');
 CmdSwitchBool prm_cppfile(switchParser, 'i');
@@ -176,7 +177,7 @@ void EXEPath(char* buffer, char* filename)
 {
     char* temp;
     strcpy(buffer, filename);
-    if ((temp = (char *)strrchr(buffer, '\\')) != 0)
+    if ((temp = (char*)strrchr(buffer, '\\')) != 0)
         *(temp + 1) = 0;
     else
         buffer[0] = 0;
@@ -462,6 +463,12 @@ static void ParamTransfer(char* name)
     {
         Optimizer::cparams.prm_c99 = prm_c11.GetValue();
         Optimizer::cparams.prm_c1x = prm_c11.GetValue();
+    }
+    if (prm_c2x.GetExists())
+    {
+        Optimizer::cparams.prm_c99 = prm_c2x.GetValue();
+        Optimizer::cparams.prm_c1x = prm_c2x.GetValue();
+        Optimizer::cparams.prm_c2x = prm_c2x.GetValue();
     }
     if (MakeStubsOption.GetValue() || MakeStubsUser.GetValue() || MakeStubsContinue.GetValue() || MakeStubsContinueUser.GetValue())
         Optimizer::cparams.prm_makestubs = true;
@@ -779,15 +786,15 @@ void setglbdefs(void)
     preProcessor->Define("__STDC__", "1");
 
     // for libcxx 10
-//    preProcessor->Define("__need_size_t", "1");
-//    preProcessor->Define("__need_FILE", "1");
-//    preProcessor->Define("__need_wint_t", "1");
+    //    preProcessor->Define("__need_size_t", "1");
+    //    preProcessor->Define("__need_FILE", "1");
+    //    preProcessor->Define("__need_wint_t", "1");
 
     if (Optimizer::cparams.prm_c99 || Optimizer::cparams.prm_c1x || Optimizer::cparams.prm_cplusplus)
     {
         preProcessor->Define("__STDC_HOSTED__", Optimizer::chosenAssembler->hosted);  // hosted compiler, not embedded
     }
-    if (Optimizer::cparams.prm_c1x)
+    if (Optimizer::cparams.prm_c1x || Optimizer::cparams.prm_c2x)
     {
         preProcessor->Define("__STDC_VERSION__", "201112L");
         Optimizer::ARCH_SIZING* local_store_of_locks = Optimizer::chosenAssembler->arch->type_needsLock;
@@ -915,8 +922,8 @@ void InsertOneFile(const char* filename, char* path, int drive)
     if (firstFile.empty())
     {
         char temp[260];
-        char* p = (char *)strrchr(buffer, '/');
-        char* q = (char *)strrchr(buffer, '\\');
+        char* p = (char*)strrchr(buffer, '/');
+        char* q = (char*)strrchr(buffer, '\\');
         if (q > p)
             p = q;
         if (!p)
@@ -986,8 +993,8 @@ void setfile(char* buf, const char* orgbuf, const char* ext)
  * Get rid of a file path an add an extension to the file name
  */
 {
-    const char* p = (char *)strrchr(orgbuf, '\\');
-    const char* p1 = (char *)strrchr(orgbuf, '/');
+    const char* p = (char*)strrchr(orgbuf, '\\');
+    const char* p1 = (char*)strrchr(orgbuf, '/');
     if (p1 > p)
         p = p1;
     else if (!p)
@@ -1008,7 +1015,7 @@ void outputfile(char* buf, const char* orgbuf, const char* ext)
 
     if (buf[strlen(buf) - 1] == '\\')
     {
-        const char* p = (char *)strrchr(orgbuf, '\\');
+        const char* p = (char*)strrchr(orgbuf, '\\');
         if (p)
             p++;
         else
@@ -1125,11 +1132,11 @@ int ccinit(int argc, char* argv[])
 
     if (!getenv("ORANGEC"))
     {
-        char* p = (char *)strrchr(buffer, '\\');
+        char* p = (char*)strrchr(buffer, '\\');
         if (p)
         {
             *p = 0;
-            char* q = (char *)strrchr(buffer, '\\');
+            char* q = (char*)strrchr(buffer, '\\');
             if (q)
             {
                 *q = 0;
@@ -1205,7 +1212,7 @@ int ccinit(int argc, char* argv[])
     {
         char temp[260];
         strcpy(temp, buffer);
-        char *p1 = (char *)strrchr(temp, '/'), *p2 = (char *)strrchr(temp, '\\');
+        char *p1 = (char*)strrchr(temp, '/'), *p2 = (char*)strrchr(temp, '\\');
         if (p2 > p1)
             p1 = p2;
         else if (!p1)

--- a/src/occparse/osutil.h
+++ b/src/occparse/osutil.h
@@ -95,6 +95,7 @@ extern CmdSwitchParser switchParser;
 extern CmdSwitchBool prm_c89;
 extern CmdSwitchBool prm_c99;
 extern CmdSwitchBool prm_c11;
+extern CmdSwitchBool prm_c2x;
 extern CmdSwitchBool prm_ansi;
 extern CmdSwitchBool prm_errfile;
 extern CmdSwitchBool prm_cppfile;

--- a/src/ocpp/PreProcessor.cpp
+++ b/src/ocpp/PreProcessor.cpp
@@ -45,6 +45,8 @@ void PreProcessor::InitHash()
     hash["ifndef"] = kw::IFNDEF;
     hash["else"] = kw::ELSE;
     hash["endif"] = kw::ENDIF;
+    hash["elifdef"] = kw::ELIFDEF;
+    hash["elifndef"] = kw::ELIFNDEF;
     if (ppStart == '%')
     {
         hash["idefine"] = kw::IDEFINE;
@@ -73,8 +75,6 @@ void PreProcessor::InitHash()
         hash["elifnnum"] = kw::ELIFNNUM;
         hash["ifnstr"] = kw::IFNSTR;
         hash["elifnstr"] = kw::ELIFNSTR;
-        hash["elifdef"] = kw::ELIFDEF;
-        hash["elifndef"] = kw::ELIFNDEF;
         hash["assign"] = kw::ASSIGN;
         hash["rep"] = kw::REP;
         hash["endrep"] = kw::ENDREP;


### PR DESCRIPTION
[[__attributes__]] and [[attributes]] support mainly along with elifdef and elifndef We still have a long way to go but this basic support structure should be there

Also there's a bug with compiling this fixes along the way. Also, nullptr, can't forget that thing
And the fact that you don't need every keyword type We'll probably have to slightly modify the internal workings based on what the actual C standard deprecates (such as _Noreturn) later
This also fixes a compilation error related to the renaming of wininc