### PR TITLE
Fix the C2X issue

### DIFF
--- a/src/occparse/lex.cpp
+++ b/src/occparse/lex.cpp
@@ -508,7 +508,7 @@ KEYWORD* searchkw(const unsigned char** p)
             if (len == kw->len)
             {
                 int count = 0;
-                if (kw->matchFlags & (KW_C99 | KW_C1X))
+                if (kw->matchFlags & (KW_C99 | KW_C1X | KW_C2X))
                 {
                     if (Optimizer::cparams.prm_c99 && (kw->matchFlags & KW_C99))
                         count++;
@@ -1185,7 +1185,7 @@ e_lexType getNumber(const unsigned char** ptr, const unsigned char** end, unsign
         radix = 16;
         (*ptr)++;
     }
-    while ((Optimizer::cparams.prm_cplusplus && **ptr == '\'') || radix36(**ptr) < radix ||
+    while (((Optimizer::cparams.prm_cplusplus || Optimizer::cparams.prm_c2x) && **ptr == '\'') || radix36(**ptr) < radix ||
            (Optimizer::cparams.prm_assemble && radix36(**ptr) < 16))
     {
         if (**ptr != '\'')

--- a/src/omake/semaphores.h
+++ b/src/omake/semaphores.h
@@ -104,7 +104,10 @@ class Semaphore
         }
         if (this != &other)
         {
-            CloseHandle(handle);
+            if (!null)
+            {
+                CloseHandle(handle);
+            }
             named = other.named;
             semaphoreName = other.semaphoreName;
             this->null = other.null;


### PR DESCRIPTION
Apparently the error was being generated from the count not being high enough, when I merge this with the mainline it works perfectly.
This also contains a fix for a premature move with MSVC.

This also adds the `'` separator to C2x