### PR TITLE
Fix semaphores by just ignoring them on linux

### DIFF
--- a/src/omake/JobServer.cpp
+++ b/src/omake/JobServer.cpp
@@ -31,10 +31,12 @@ std::shared_ptr<JobServer> JobServer::GetJobServer(const std::string& auth_strin
     return std::make_shared<POSIXJobServer>(readfd, writefd);
 #endif
 }
+#ifdef _WIN32
 std::shared_ptr<JobServer> JobServer::GetJobServer(const std::string& auth_string, int max_jobs)
 {
     return std::make_shared<WINDOWSJobServer>(auth_string, max_jobs);
 }
+#endif
 std::shared_ptr<JobServer> JobServer::GetJobServer(int max_jobs, bool ignored)
 {
     (void)ignored;

--- a/src/omake/JobServer.h
+++ b/src/omake/JobServer.h
@@ -7,7 +7,9 @@
 #include <type_traits>
 #include <utility>
 #include <memory>
-#include "semaphores.h"
+#ifdef _WIN32
+#    include "semaphores.h"
+#endif
 // The main issue with using semaphores alone for Linux is that named semaphores
 // on linux can't be used without knowing the state of every application taking
 // the named semaphores, a solution to this is to use a jobserver, in order for
@@ -70,20 +72,21 @@ class POSIXJobServer : public JobServer
     POSIXJobServer(int max_jobs);
     POSIXJobServer(int read, int write);
 };
+#ifdef _WIN32
 class WINDOWSJobServer : public JobServer
 {
     friend class JobServer;
-#ifdef _WIN32
-#    ifdef UNICODE
+#    ifdef _WIN32
+#        ifdef UNICODE
     // Use a consistent strategy so that windows doesn't yell at us, I know we don't work in wide strings except in obrc often
     // so this is here for posterity *AND* ease of use
     using string_type = std::wstring;
+#        else
+    using string_type = std::string;
+#        endif
 #    else
     using string_type = std::string;
 #    endif
-#else
-    using string_type = std::string;
-#endif
   private:
     // Name of the server, use std::string or std::wstring, we do this for compatibility reasons
     string_type server_name;
@@ -103,4 +106,5 @@ class WINDOWSJobServer : public JobServer
     // Interprocess semaphores require names
     WINDOWSJobServer(const string_type& server_name);
 };
+#endif
 }  // namespace OMAKE

--- a/src/omake/JobServer.h
+++ b/src/omake/JobServer.h
@@ -48,9 +48,12 @@ class JobServer : public IJobServer
     static std::shared_ptr<JobServer> GetJobServer(int max_jobs);
     // Opens a job server with a specified authorization code, this is *AFAR* parsing the --jobserver-auth string
     static std::shared_ptr<JobServer> GetJobServer(const std::string& auth_string);
+#ifdef _WIN32
+
     // temporary GetJobServer for compatibility reasons with old code, instead of moving things into JobServer here, we're moving
     // them out
     static std::shared_ptr<JobServer> GetJobServer(const std::string& auth_string, int max_jobs);
+#endif
     // Creates an OMAKE compatible job server, allowing for the main class to move out when needed
     static std::shared_ptr<JobServer> GetJobServer(int max_jobs, bool ignored);
 };

--- a/src/omake/os_specific/Linux/Linux_Jobserver.cpp
+++ b/src/omake/os_specific/Linux/Linux_Jobserver.cpp
@@ -14,7 +14,7 @@ bool POSIXJobServer::TryTakeNewJob()
     {
         throw std::runtime_error("Job server used without initializing the underlying parameters");
     }
-//    if (current_jobs != 0)
+    //    if (current_jobs != 0)
     {
         int err = 0;
         char only_buffer;
@@ -40,8 +40,8 @@ bool POSIXJobServer::TryTakeNewJob()
             }
         }
     }
-//    current_jobs++;
-//    return true;
+    //    current_jobs++;
+    //    return true;
 }
 bool POSIXJobServer::TakeNewJob()
 {
@@ -49,7 +49,7 @@ bool POSIXJobServer::TakeNewJob()
     {
         throw std::runtime_error("Job server used without initializing the underlying parameters");
     }
-//    if (current_jobs != 0)
+    //    if (current_jobs != 0)
     {
         int err = 0;
         char only_buffer;
@@ -76,8 +76,8 @@ bool POSIXJobServer::TakeNewJob()
             }
         }
     }
-//    current_jobs++;
-//    return true;
+    //    current_jobs++;
+    //    return true;
 }
 bool POSIXJobServer::ReleaseJob()
 {
@@ -89,7 +89,7 @@ bool POSIXJobServer::ReleaseJob()
     {
         throw std::runtime_error("Job server has returned more jobs than it has consumed");
     }
-    else //if (current_jobs != 1)
+    else  // if (current_jobs != 1)
     {
         int err = 0;
         char write_buffer = '1';
@@ -175,6 +175,7 @@ std::string POSIXJobServer::PassThroughCommandString()
     stream << readfd << ',' << writefd;
     return stream.str();
 }
+#ifdef _WIN32
 WINDOWSJobServer::WINDOWSJobServer(const string_type& server_name)
 {
     throw std::runtime_error("Windows job servers are unavailable on POSIX");
@@ -190,4 +191,5 @@ std::string WINDOWSJobServer::PassThroughCommandString()
 bool WINDOWSJobServer::TryTakeNewJob() { throw std::runtime_error("Windows job servers are unavailable on POSIX"); }
 bool WINDOWSJobServer::TakeNewJob() { throw std::runtime_error("Windows job servers are unavailable on POSIX"); }
 bool WINDOWSJobServer::ReleaseJob() { throw std::runtime_error("Windows job servers are unavailable on POSIX"); }
+#endif
 }  // namespace OMAKE


### PR DESCRIPTION
I've noticed you're playing around with semaphores.h, if there's any issues with it compiling on linux it's *not* intended for linux anymore, the main issue is fundamentally that linux semaphores don't function the way we need them to, thus the POSIXJobServer which is pipe-arbitrated