### PR TITLE
Fix building with MinGW-w64 based Clang

### DIFF
--- a/src/occopt/memory.h
+++ b/src/occopt/memory.h
@@ -24,7 +24,7 @@
  */
 
 #include "ctypes.h"
-#ifdef BORLAND
+#if defined(BORLAND) || (defined(__MINGW32__) && defined(__clang__))
 // hack for buggy embarcadero compiler
 #    define beLocalAlloc(x) Alloc(x)
 #    define beGlobalAlloc(x) globalAlloc(x)


### PR DESCRIPTION
It turned out MinGW-w64 based Clang needs the same treatment as the Embarcadero Compiler.