### PR TITLE
Support base file names with dots and icf output for all provided source files (not only one)

### DIFF
--- a/BUSY
+++ b/BUSY
@@ -68,6 +68,9 @@ let common : SourceSet {
         ./src/util/Utils.h
         ./src/util/xml.h
 
+        ./src/ocpp/Floating.cpp
+        ./src/ocpp/Floating.h
+
         ./src/occopt/config.cpp
         ./src/occopt/config.h
         ./src/occopt/configx86.cpp
@@ -143,7 +146,6 @@ let orangefront : Executable {
         ./src/occparse/unmangle.cpp
         ./src/occparse/wseh.cpp
         ./src/ocpp/Errors.cpp
-        ./src/ocpp/Floating.cpp
         ./src/ocpp/InputFile.cpp
         ./src/ocpp/MakeStubs.cpp
         ./src/ocpp/PipeArbitrator.cpp
@@ -213,7 +215,6 @@ let orangefront : Executable {
         ./src/occparse/winmode.h
         ./src/occparse/wseh.h
         ./src/ocpp/Errors.h
-        ./src/ocpp/Floating.h
         ./src/ocpp/InputFile.h
         ./src/ocpp/MakeStubs.h
         ./src/ocpp/PipeArbitrator.h
@@ -282,16 +283,11 @@ let orangeopt : Executable {
         ./src/occopt/istren.h
         ./src/occopt/localprotect.cpp
         ./src/occopt/localprotect.h
-        ./src/occopt/msilprocess.cpp
         ./src/occopt/optmain.cpp
         ./src/occopt/optmain.h
         ./src/occopt/optmodulerun.cpp
-        ./src/occopt/rewritemsil.cpp
-        ./src/occopt/rewritemsil.h
         ./src/occopt/rewritex86.cpp
         ./src/occopt/rewritex86.h
-
-        ./src/ocpp/Floating.cpp
      ]
 }
 

--- a/BUSY
+++ b/BUSY
@@ -38,7 +38,7 @@ let config : Config {
 
 let config2 : Config {
     .include_dirs += [ . ./src/occopt ./src/util ./src/ocpp ]
-    .defines += [ "ORANGE_NO_MSIL" "ORANGE_NO_INASM" ]
+    .defines += [ "ORANGE_NO_MSIL" "ORANGE_NO_INASM" "ORANGE_NAMES_WITH_DOTS" ]
 }
 
 let common : SourceSet {

--- a/src/occopt/optmain.cpp
+++ b/src/occopt/optmain.cpp
@@ -431,7 +431,7 @@ void SaveFile(std::string& name, SharedMemory* optimizerMem)
         char buf[260];
         strcpy(buf, name.c_str());
         Utils::StripExt(buf);
-        strcat(buf, ".icd2");
+        Utils::AddExt(buf, ".icd2");
         icdFile = fopen(buf, "w");
         if (!icdFile)
             return;
@@ -495,7 +495,7 @@ int main(int argc, char* argv[])
             strcpy(buf, files[1].c_str());
             Utils::StripExt(buf);
             strcat(buf, "_1");
-            strcat(buf, ".icf");
+            Utils::AddExt(buf, ".icf");
             outputFile = buf;
         }
         FILE* fil = fopen(files[1].c_str(), "rb");

--- a/src/occopt/optmain.cpp
+++ b/src/occopt/optmain.cpp
@@ -203,9 +203,11 @@ void examine_icode(QUAD* head)
 {
     switch (architecture)
     {
+#ifndef ORANGE_NO_MSIL
         case ARCHITECTURE_MSIL:
             msil_examine_icode(head);
             break;
+#endif
         case ARCHITECTURE_X86:
             x86_examine_icode(head);
             break;

--- a/src/occopt/optmain.cpp
+++ b/src/occopt/optmain.cpp
@@ -431,7 +431,7 @@ void SaveFile(std::string& name, SharedMemory* optimizerMem)
         char buf[260];
         strcpy(buf, name.c_str());
         Utils::StripExt(buf);
-        Utils::AddExt(buf, ".icd2");
+        strcat(buf, ".icd2");
         icdFile = fopen(buf, "w");
         if (!icdFile)
             return;
@@ -495,7 +495,7 @@ int main(int argc, char* argv[])
             strcpy(buf, files[1].c_str());
             Utils::StripExt(buf);
             strcat(buf, "_1");
-            Utils::AddExt(buf, ".icf");
+            strcat(buf, ".icf");
             outputFile = buf;
         }
         FILE* fil = fopen(files[1].c_str(), "rb");

--- a/src/occparse/occparse.cpp
+++ b/src/occparse/occparse.cpp
@@ -564,7 +564,7 @@ int main(int argc, char* argv[])
         {
             CompletionCompiler::ccNewFile(buffer, true);
         }
-        Utils::AddExt(buffer, ".C");
+        // why? Utils::AddExt(buffer, ".C");
         if (prm_std.GetExists())
         {
             if (prm_std.GetValue() == "c89")

--- a/src/occparse/occparse.cpp
+++ b/src/occparse/occparse.cpp
@@ -564,7 +564,6 @@ int main(int argc, char* argv[])
         {
             CompletionCompiler::ccNewFile(buffer, true);
         }
-        // why? Utils::AddExt(buffer, ".C");
         if (prm_std.GetExists())
         {
             if (prm_std.GetValue() == "c89")
@@ -712,6 +711,18 @@ int main(int argc, char* argv[])
                 }
                 if (Optimizer::cparams.prm_icdfile)
                     Optimizer::OutputIcdFile();
+                if (compileToFile)
+                {
+                    // compile to file
+                    strcpy(realOutFile, (const char*)clist->data);
+                    Utils::StripExt(realOutFile);
+                    Utils::AddExt(realOutFile, ".icf");
+                    FILE* fil = fopen(realOutFile, "wb");
+                    if (!fil)
+                        Utils::Fatal("Cannot open '%s' for write", realOutFile);
+                    Optimizer::WriteMappingFile(parserMem, fil);
+                    fclose(fil);
+                }
                 Optimizer::InitIntermediate();
             }
         }
@@ -809,22 +820,7 @@ int main(int argc, char* argv[])
             }
 #endif
     }
-    if (compileToFile)
-    {
-        // compile to file
-        if (Optimizer::outputFileName.empty())
-            strcpy(realOutFile, firstFile);
-        else
-            strcpy(realOutFile, Optimizer::outputFileName.c_str());
-        Utils::StripExt(realOutFile);
-        Utils::AddExt(realOutFile, ".icf");
-        int size = Optimizer::GetOutputSize();
-        FILE* fil = fopen(realOutFile, "wb");
-        if (!fil)
-            Utils::Fatal("Cannot open '%s' for write", realOutFile);
-        Optimizer::WriteMappingFile(parserMem, fil);
-        fclose(fil);
-    }
+
     oFree();
     globalFree();
     delete parserMem;

--- a/src/occparse/occparse.cpp
+++ b/src/occparse/occparse.cpp
@@ -659,7 +659,7 @@ int main(int argc, char* argv[])
                 else
                 {
                     Utils::StripExt(buffer);
-                    Utils::AddExt(buffer, ".i");
+                    strcat(buffer, ".i");
                 }
                 strcpy(cppfile, buffer);
 
@@ -673,7 +673,7 @@ int main(int argc, char* argv[])
             if (Optimizer::cparams.prm_errfile)
             {
                 Utils::StripExt(buffer);
-                Utils::AddExt(buffer, ".err");
+                strcat(buffer, ".err");
                 errFile = fopen(buffer, "w");
                 if (!errFile)
                 {
@@ -685,7 +685,7 @@ int main(int argc, char* argv[])
             if (Optimizer::cparams.prm_icdfile)
             {
                 Utils::StripExt(buffer);
-                Utils::AddExt(buffer, ".icd");
+                strcat(buffer, ".icd");
                 Optimizer::icdFile = fopen(buffer, "w");
                 if (!Optimizer::icdFile)
                 {
@@ -716,7 +716,7 @@ int main(int argc, char* argv[])
                     // compile to file
                     strcpy(realOutFile, (const char*)clist->data);
                     Utils::StripExt(realOutFile);
-                    Utils::AddExt(realOutFile, ".icf");
+                    strcat(realOutFile, ".icf");
                     FILE* fil = fopen(realOutFile, "wb");
                     if (!fil)
                         Utils::Fatal("Cannot open '%s' for write", realOutFile);

--- a/src/occparse/occparse.cpp
+++ b/src/occparse/occparse.cpp
@@ -564,6 +564,9 @@ int main(int argc, char* argv[])
         {
             CompletionCompiler::ccNewFile(buffer, true);
         }
+#ifndef ORANGE_NAMES_WITH_DOTS
+        Utils::AddExt(buffer, ".c");
+#endif
         if (prm_std.GetExists())
         {
             if (prm_std.GetValue() == "c89")
@@ -659,7 +662,7 @@ int main(int argc, char* argv[])
                 else
                 {
                     Utils::StripExt(buffer);
-                    strcat(buffer, ".i");
+                    Utils::AddExt(buffer, ".i");
                 }
                 strcpy(cppfile, buffer);
 
@@ -673,7 +676,7 @@ int main(int argc, char* argv[])
             if (Optimizer::cparams.prm_errfile)
             {
                 Utils::StripExt(buffer);
-                strcat(buffer, ".err");
+                Utils::AddExt(buffer, ".err");
                 errFile = fopen(buffer, "w");
                 if (!errFile)
                 {
@@ -685,7 +688,7 @@ int main(int argc, char* argv[])
             if (Optimizer::cparams.prm_icdfile)
             {
                 Utils::StripExt(buffer);
-                strcat(buffer, ".icd");
+                Utils::AddExt(buffer, ".icd");
                 Optimizer::icdFile = fopen(buffer, "w");
                 if (!Optimizer::icdFile)
                 {
@@ -716,7 +719,7 @@ int main(int argc, char* argv[])
                     // compile to file
                     strcpy(realOutFile, (const char*)clist->data);
                     Utils::StripExt(realOutFile);
-                    strcat(realOutFile, ".icf");
+                    Utils::AddExt(realOutFile, ".icf");
                     FILE* fil = fopen(realOutFile, "wb");
                     if (!fil)
                         Utils::Fatal("Cannot open '%s' for write", realOutFile);

--- a/src/occparse/osutil.cpp
+++ b/src/occparse/osutil.cpp
@@ -1018,7 +1018,8 @@ void InsertOneFile(const char* filename, char* path, int drive)
         buffer[0] = a;
     if (!inserted)
     {
-        Utils::AddExt(buffer, ".c");
+        // RK: why should filenames without extension be supported and default to .c? What about .cpp?
+        // Utils::AddExt(buffer, ".c");
         newbuffer = (char*)malloc(strlen(buffer) + 1);
         if (!newbuffer)
             return;
@@ -1103,7 +1104,8 @@ void outputfile(char* buf, const char* orgbuf, const char* ext)
     }
     else if (prm_output.GetExists() && !MakeStubsContinue.GetValue() && !MakeStubsContinueUser.GetValue())
     {
-        Utils::AddExt(buf, ext);
+        // TODO RK: why would we change the output filename given by the user?
+        // Utils::AddExt(buf, ext);
     }
     else
     {

--- a/src/occparse/osutil.cpp
+++ b/src/occparse/osutil.cpp
@@ -1104,8 +1104,14 @@ void outputfile(char* buf, const char* orgbuf, const char* ext)
     }
     else if (prm_output.GetExists() && !MakeStubsContinue.GetValue() && !MakeStubsContinueUser.GetValue())
     {
+#if TARGET_OS_WINDOWS
+        char* pos = (char*)strrchr(buf, '.');
+        if (!pos || (*(pos - 1) == '.') || (*(pos + 1) == '\\'))
+            strcat(buf, ext);
+#else
         if( !Utils::HasExt(buf, ext) )
             Utils::AddExt(buf, ext);
+#endif
     }
     else
     {

--- a/src/occparse/osutil.cpp
+++ b/src/occparse/osutil.cpp
@@ -1104,8 +1104,8 @@ void outputfile(char* buf, const char* orgbuf, const char* ext)
     }
     else if (prm_output.GetExists() && !MakeStubsContinue.GetValue() && !MakeStubsContinueUser.GetValue())
     {
-        // TODO RK: why would we change the output filename given by the user?
-        // Utils::AddExt(buf, ext);
+        if( !Utils::HasExt(buf, ext) )
+            Utils::AddExt(buf, ext);
     }
     else
     {

--- a/src/occparse/osutil.cpp
+++ b/src/occparse/osutil.cpp
@@ -1010,7 +1010,7 @@ void InsertOneFile(const char* filename, char* path, int drive)
         strcpy(temp, p);
         Utils::StripExt(temp);
         if (!Optimizer::cparams.prm_compileonly && !Optimizer::cparams.prm_assemble)
-            Utils::AddExt(temp, ".exe");
+            strcat(temp, ".exe");
         firstFile = temp;
     }
     inserted = insert_noncompile_file(buffer);
@@ -1100,14 +1100,12 @@ void outputfile(char* buf, const char* orgbuf, const char* ext)
             p = orgbuf;
         strcat(buf, p);
         Utils::StripExt(buf);
-        Utils::AddExt(buf, ext);
+        strcat(buf, ext);
     }
     else if (prm_output.GetExists() && !MakeStubsContinue.GetValue() && !MakeStubsContinueUser.GetValue())
     {
 #if TARGET_OS_WINDOWS
-        char* pos = (char*)strrchr(buf, '.');
-        if (!pos || (*(pos - 1) == '.') || (*(pos + 1) == '\\'))
-            strcat(buf, ext);
+        Utils::AddExt(buf, ext);
 #else
         if( !Utils::HasExt(buf, ext) )
             Utils::AddExt(buf, ext);

--- a/src/occparse/osutil.cpp
+++ b/src/occparse/osutil.cpp
@@ -1010,7 +1010,7 @@ void InsertOneFile(const char* filename, char* path, int drive)
         strcpy(temp, p);
         Utils::StripExt(temp);
         if (!Optimizer::cparams.prm_compileonly && !Optimizer::cparams.prm_assemble)
-            strcat(temp, ".exe");
+            Utils::AddExt(temp, ".exe");
         firstFile = temp;
     }
     inserted = insert_noncompile_file(buffer);
@@ -1018,8 +1018,9 @@ void InsertOneFile(const char* filename, char* path, int drive)
         buffer[0] = a;
     if (!inserted)
     {
-        // RK: why should filenames without extension be supported and default to .c? What about .cpp?
-        // Utils::AddExt(buffer, ".c");
+#ifndef ORANGE_NAMES_WITH_DOTS
+        Utils::AddExt(buffer, ".c");
+#endif
         newbuffer = (char*)malloc(strlen(buffer) + 1);
         if (!newbuffer)
             return;
@@ -1100,15 +1101,12 @@ void outputfile(char* buf, const char* orgbuf, const char* ext)
             p = orgbuf;
         strcat(buf, p);
         Utils::StripExt(buf);
-        strcat(buf, ext);
+        Utils::AddExt(buf, ext);
     }
     else if (prm_output.GetExists() && !MakeStubsContinue.GetValue() && !MakeStubsContinueUser.GetValue())
     {
-#if TARGET_OS_WINDOWS
+#ifndef ORANGE_NAMES_WITH_DOTS
         Utils::AddExt(buf, ext);
-#else
-        if( !Utils::HasExt(buf, ext) )
-            Utils::AddExt(buf, ext);
 #endif
     }
     else

--- a/src/util/Utils.cpp
+++ b/src/util/Utils.cpp
@@ -320,7 +320,7 @@ FILE* Utils::TempName(std::string& name)
 void Utils::AddExt(char* buffer, const char* ext)
 {
     char* pos = (char*)strrchr(buffer, '.');
-    if (!pos || (*(pos - 1) == '.') || (*(pos + 1) == '\\'))
+    if (!pos || strcmp(pos,ext) != 0 )
         strcat(buffer, ext);
 }
 

--- a/src/util/Utils.cpp
+++ b/src/util/Utils.cpp
@@ -315,13 +315,14 @@ FILE* Utils::TempName(std::string& name)
 }
 
 /*
- * Add ext to buffer
+ * If no extension, add the one specified
  */
 void Utils::AddExt(char* buffer, const char* ext)
 {
-    // RK: back to the original code
+#ifndef ORANGE_NAMES_WITH_DOTS
     char* pos = (char*)strrchr(buffer, '.');
     if (!pos || (*(pos - 1) == '.') || (*(pos + 1) == '\\'))
+#endif
         strcat(buffer, ext);
 }
 

--- a/src/util/Utils.cpp
+++ b/src/util/Utils.cpp
@@ -319,9 +319,9 @@ FILE* Utils::TempName(std::string& name)
  */
 void Utils::AddExt(char* buffer, const char* ext)
 {
-    //char* pos = (char*)strrchr(buffer, '.');
-    //if (!pos || strcmp(pos,ext) != 0 )
-    // NOTE: the strcmp gives no added value; AddExt is always preceded by StripExt
+    // RK: back to the original code
+    char* pos = (char*)strrchr(buffer, '.');
+    if (!pos || (*(pos - 1) == '.') || (*(pos + 1) == '\\'))
         strcat(buffer, ext);
 }
 

--- a/src/util/Utils.cpp
+++ b/src/util/Utils.cpp
@@ -315,12 +315,13 @@ FILE* Utils::TempName(std::string& name)
 }
 
 /*
- * If no extension, add the one specified
+ * Add ext to buffer
  */
 void Utils::AddExt(char* buffer, const char* ext)
 {
-    char* pos = (char*)strrchr(buffer, '.');
-    if (!pos || strcmp(pos,ext) != 0 )
+    //char* pos = (char*)strrchr(buffer, '.');
+    //if (!pos || strcmp(pos,ext) != 0 )
+    // NOTE: the strcmp gives no added value; AddExt is always preceded by StripExt
         strcat(buffer, ext);
 }
 


### PR DESCRIPTION
This is the continuation of https://github.com/LADSoft/OrangeC/issues/1031 which is hereby closed.

I checked where the functions using Utils::AddExt are used and came to the conclusion that my modification of Utils::AddExt works up to the few cases where a default suffix should be added when the user provides a filename without suffix. But from my humble point of view this case should rather be treated as an error; it might have been a decent behaviour as long as Orange only was a C compiler, but today a plethora of possible suffices is expected, so it doesn't make sense to just arbitrarily select one. 

Conclusion: the compiler doesn't support filenames provided by the user without suffix anymore, and doesn't change the suffix of a user provided filename (as also suggested by [GitMensch](https://github.com/GitMensch)). And the generation of output filenames by chopping the suffix and adding a new one is supported.

I also modified the code order in occparse so the icf output is in the loop through all provided source files (the original version instead wrote the icf of the last file with the name of the first file).