### PR TITLE
Support base file names with dots

### DIFF
--- a/BUSY
+++ b/BUSY
@@ -68,6 +68,9 @@ let common : SourceSet {
         ./src/util/Utils.h
         ./src/util/xml.h
 
+        ./src/ocpp/Floating.cpp
+        ./src/ocpp/Floating.h
+
         ./src/occopt/config.cpp
         ./src/occopt/config.h
         ./src/occopt/configx86.cpp
@@ -143,7 +146,6 @@ let orangefront : Executable {
         ./src/occparse/unmangle.cpp
         ./src/occparse/wseh.cpp
         ./src/ocpp/Errors.cpp
-        ./src/ocpp/Floating.cpp
         ./src/ocpp/InputFile.cpp
         ./src/ocpp/MakeStubs.cpp
         ./src/ocpp/PipeArbitrator.cpp
@@ -213,7 +215,6 @@ let orangefront : Executable {
         ./src/occparse/winmode.h
         ./src/occparse/wseh.h
         ./src/ocpp/Errors.h
-        ./src/ocpp/Floating.h
         ./src/ocpp/InputFile.h
         ./src/ocpp/MakeStubs.h
         ./src/ocpp/PipeArbitrator.h
@@ -282,16 +283,11 @@ let orangeopt : Executable {
         ./src/occopt/istren.h
         ./src/occopt/localprotect.cpp
         ./src/occopt/localprotect.h
-        ./src/occopt/msilprocess.cpp
         ./src/occopt/optmain.cpp
         ./src/occopt/optmain.h
         ./src/occopt/optmodulerun.cpp
-        ./src/occopt/rewritemsil.cpp
-        ./src/occopt/rewritemsil.h
         ./src/occopt/rewritex86.cpp
         ./src/occopt/rewritex86.h
-
-        ./src/ocpp/Floating.cpp
      ]
 }
 

--- a/BUSY
+++ b/BUSY
@@ -38,7 +38,7 @@ let config : Config {
 
 let config2 : Config {
     .include_dirs += [ . ./src/occopt ./src/util ./src/ocpp ]
-    .defines += [ "ORANGE_NO_MSIL" "ORANGE_NO_INASM" ]
+    .defines += [ "ORANGE_NO_MSIL" "ORANGE_NO_INASM" "ORANGE_NAMES_WITH_DOTS" ]
 }
 
 let common : SourceSet {

--- a/src/occopt/optmain.cpp
+++ b/src/occopt/optmain.cpp
@@ -203,9 +203,11 @@ void examine_icode(QUAD* head)
 {
     switch (architecture)
     {
-        case ARCHITECTURE_MSIL:
+#ifndef ORANGE_NO_MSIL
+    case ARCHITECTURE_MSIL:
             msil_examine_icode(head);
             break;
+#endif
         case ARCHITECTURE_X86:
             x86_examine_icode(head);
             break;

--- a/src/occparse/occparse.cpp
+++ b/src/occparse/occparse.cpp
@@ -564,7 +564,9 @@ int main(int argc, char* argv[])
         {
             CompletionCompiler::ccNewFile(buffer, true);
         }
+#ifndef ORANGE_NAMES_WITH_DOTS
         Utils::AddExt(buffer, ".C");
+#endif
         if (prm_std.GetExists())
         {
             if (prm_std.GetValue() == "c89")

--- a/src/occparse/osutil.cpp
+++ b/src/occparse/osutil.cpp
@@ -1018,7 +1018,9 @@ void InsertOneFile(const char* filename, char* path, int drive)
         buffer[0] = a;
     if (!inserted)
     {
+#ifndef ORANGE_NAMES_WITH_DOTS
         Utils::AddExt(buffer, ".c");
+#endif
         newbuffer = (char*)malloc(strlen(buffer) + 1);
         if (!newbuffer)
             return;
@@ -1103,7 +1105,9 @@ void outputfile(char* buf, const char* orgbuf, const char* ext)
     }
     else if (prm_output.GetExists() && !MakeStubsContinue.GetValue() && !MakeStubsContinueUser.GetValue())
     {
+#ifndef ORANGE_NAMES_WITH_DOTS
         Utils::AddExt(buf, ext);
+#endif
     }
     else
     {

--- a/src/util/Utils.cpp
+++ b/src/util/Utils.cpp
@@ -319,8 +319,10 @@ FILE* Utils::TempName(std::string& name)
  */
 void Utils::AddExt(char* buffer, const char* ext)
 {
+#ifndef ORANGE_NAMES_WITH_DOTS
     char* pos = (char*)strrchr(buffer, '.');
     if (!pos || (*(pos - 1) == '.') || (*(pos + 1) == '\\'))
+#endif
         strcat(buffer, ext);
 }
 


### PR DESCRIPTION
This is the replacement for https://github.com/LADSoft/OrangeC/pull/1032 in the hope that the windows build now works or is at least easier to fix.