### PR TITLE
Orange front and opt successfully build with GCC 4.8 (-std=c++11) on Linux

### DIFF
--- a/BUSY
+++ b/BUSY
@@ -68,6 +68,9 @@ let common : SourceSet {
         ./src/util/Utils.h
         ./src/util/xml.h
 
+        ./src/ocpp/Floating.cpp
+        ./src/ocpp/Floating.h
+
         ./src/occopt/config.cpp
         ./src/occopt/config.h
         ./src/occopt/configx86.cpp
@@ -143,7 +146,6 @@ let orangefront : Executable {
         ./src/occparse/unmangle.cpp
         ./src/occparse/wseh.cpp
         ./src/ocpp/Errors.cpp
-        ./src/ocpp/Floating.cpp
         ./src/ocpp/InputFile.cpp
         ./src/ocpp/MakeStubs.cpp
         ./src/ocpp/PipeArbitrator.cpp
@@ -213,7 +215,6 @@ let orangefront : Executable {
         ./src/occparse/winmode.h
         ./src/occparse/wseh.h
         ./src/ocpp/Errors.h
-        ./src/ocpp/Floating.h
         ./src/ocpp/InputFile.h
         ./src/ocpp/MakeStubs.h
         ./src/ocpp/PipeArbitrator.h
@@ -282,16 +283,11 @@ let orangeopt : Executable {
         ./src/occopt/istren.h
         ./src/occopt/localprotect.cpp
         ./src/occopt/localprotect.h
-        ./src/occopt/msilprocess.cpp
         ./src/occopt/optmain.cpp
         ./src/occopt/optmain.h
         ./src/occopt/optmodulerun.cpp
-        ./src/occopt/rewritemsil.cpp
-        ./src/occopt/rewritemsil.h
         ./src/occopt/rewritex86.cpp
         ./src/occopt/rewritex86.h
-
-        ./src/ocpp/Floating.cpp
      ]
 }
 

--- a/BUSY
+++ b/BUSY
@@ -7,8 +7,8 @@
 
 let config : Config {
     if (target_toolchain == `gcc) {
-        # NOTE: this build has been successfully run on Linux x86 with GCC 12 and Linux x64 with GCC 10
-        .lib_names += [ "m" "stdc++" ]
+        # NOTE: this build has been successfully run on Linux x86 with GCC 4.8 and 12, and Linux x64 with GCC 10
+        .lib_names += [ "stdc++" "m" ] # NOTE: order is relevant to avoid missing floor reference from stl
         if build_mode == `debug {
             .ldflags += "-shared-libgcc"
         } else {

--- a/BUSY
+++ b/BUSY
@@ -14,14 +14,14 @@ let config : Config {
         } else {
             .ldflags += "-static"
         }
-        .cflags_cc += "-std=c++14"
+        .cflags_cc += "-std=c++11"
     	.defines += "HAVE_UNISTD_H"
     }else if (target_toolchain == `clang) {
     	# NOTE: this is an experimental compile with Clang 4.0.1 and the libc++ headers;
     	# it compiles when the original C headers from the system are available
     	# linking is yet another adventure to be solved
         .lib_names += [ "m" "stdc++" ]
-        .cflags_cc += "-std=c++14";
+        .cflags_cc += "-std=c++11";
     	.defines += "HAVE_UNISTD_H"
         .include_dirs += [
             //home/me/Programme/clang-4/includes

--- a/src/occopt/optmain.cpp
+++ b/src/occopt/optmain.cpp
@@ -95,10 +95,12 @@ void* operator new(size_t aa)
     {
         // If malloc fails and there is a new_handler,
         // call it to try free up memory.
+#if __GNUC__ > 4
         std::new_handler nh = std::get_new_handler();
         if (nh)
             nh();
         else
+#endif
             throw std::bad_alloc();
     }
     rv->size = bb;

--- a/src/occparse/c.h
+++ b/src/occparse/c.h
@@ -82,7 +82,7 @@ public:
     SymbolTable<T>* Next() const { return next_; }
     void Chain(SymbolTable<T>* chain) { chain_ = chain; }
     SymbolTable<T>* Chain() const { return chain_; }
-    auto ReleaseNext() { auto rv = next_; if (next_) next_ = next_->next_; return rv; }
+    SymbolTable<T>* ReleaseNext() { SymbolTable<T>* rv = next_; if (next_) next_ = next_->next_; return rv; }
     int Block() const { return blockLevel_; }
     void Block(int level) { blockLevel_ = level; }
 
@@ -1251,9 +1251,7 @@ typedef struct _atomicData
 
 CONSTEXPR inline TYPE* basetype(TYPE* a)
 {
-    if (a)
-        a = a->rootType;
-    return a;
+    return a ? a->rootType : a;
 }
 
 CONSTEXPR inline bool __isref(TYPE* x) { return (x)->type == BasicType::lref_ || (x)->type == BasicType::rref_; }

--- a/src/occparse/ccerr.cpp
+++ b/src/occparse/ccerr.cpp
@@ -521,7 +521,7 @@ int printerr(int err, const char* file, int line, ...)
 
 bool RequiresDialect::Base(Dialect cpp, int err, const char* feature)
 {
-    static std::unordered_map<Dialect, const char*> lookup = {
+    static std::unordered_map<Dialect, const char*,EnumClassHash> lookup = {
         {Dialect::c89, "C89"},     {Dialect::c99, "C99"},     {Dialect::c11, "C11"},    {Dialect::c2x, "C23"},
         {Dialect::cpp11, "C++11"}, {Dialect::cpp14, "C++14"}, {Dialect::cpp17, "C++17"}};
     if (cpp >= Dialect::c89 && cpp < Dialect::cpp11)

--- a/src/occparse/compiler.h
+++ b/src/occparse/compiler.h
@@ -51,6 +51,15 @@
 #include "c.h"
 #include "beinterfdefs.h"
 
+struct EnumClassHash
+{
+    template <typename T>
+    std::size_t operator()(T t) const
+    {
+        return static_cast<std::size_t>(t);
+    }
+};
+
 #define M_LN2 0.693147180559945309417
 #define M_LN10 2.30258509299404568402
 

--- a/src/occparse/declcpp.cpp
+++ b/src/occparse/declcpp.cpp
@@ -3996,7 +3996,6 @@ bool ParseAttributeSpecifiers(LEXLIST** lex, SYMBOL* funcsp, bool always)
                         }
                         else
                         {
-                            using namespace std::literals;
                             std::string stripped_ver = StripUnderscores((std::string)(*lex)->data->value.s.a);
                             if (stripped_ver == occNamespace)
                             {
@@ -4132,7 +4131,7 @@ bool ParseAttributeSpecifiers(LEXLIST** lex, SYMBOL* funcsp, bool always)
                             else
                             {
 
-                                if (stripped_ver == "noreturn"s)
+                                if (stripped_ver == "noreturn")
                                 {
                                     *lex = getsym();
                                     special = true;
@@ -4140,30 +4139,30 @@ bool ParseAttributeSpecifiers(LEXLIST** lex, SYMBOL* funcsp, bool always)
                                         error(ERR_TOO_MANY_LINKAGE_SPECIFIERS);
                                     basisAttribs.inheritable.linkage3 = Linkage::noreturn_;
                                 }
-                                else if (stripped_ver == "carries_dependency"s)
+                                else if (stripped_ver == "carries_dependency")
                                 {
                                     *lex = getsym();
                                     special = true;
                                 }
-                                else if (stripped_ver == "fallthrough"s)
+                                else if (stripped_ver == "fallthrough")
                                 {
                                     *lex = getsym();
                                     basisAttribs.uninheritable.fallthrough = true;
                                 }
-                                else if (stripped_ver == "maybe_unused"s)
+                                else if (stripped_ver == "maybe_unused")
                                 {
                                     *lex = getsym();
                                     basisAttribs.uninheritable.maybe_unused = true;
 
                                 }
-                                else if (stripped_ver == "nodiscard"s)
+                                else if (stripped_ver == "nodiscard")
                                 {
                                     *lex = getsym();
                                     basisAttribs.uninheritable.nodiscard = true;
                                 }
                                 else
                                 {
-                                    if (stripped_ver == "deprecated"s)
+                                    if (stripped_ver == "deprecated")
                                         basisAttribs.uninheritable.deprecationText = (char*)-1;
                                     *lex = getsym();
                                     if (MATCHKW(*lex, Keyword::classsel_))

--- a/src/occparse/expreval.cpp
+++ b/src/occparse/expreval.cpp
@@ -83,7 +83,7 @@ namespace Parser
 typedef bool(*EvalFunc)(LEXLIST* lex, SYMBOL* funcsp, TYPE* atp, TYPE** resulttp, EXPRESSION** resultexp, TYPE* lefttp,
                        EXPRESSION* leftexp, TYPE* righttp, EXPRESSION* rightexp, bool ismutable, int flags);
 
-static std::unordered_map<Keyword, EvalFunc> dispatcher = {
+static std::unordered_map<Keyword, EvalFunc, EnumClassHash> dispatcher = {
     {Keyword::dotstar_, eval_binary_pm},
     {Keyword::pointstar_, eval_binary_pm},
     {Keyword::star_, eval_binary_times},

--- a/src/occparse/iexpr.cpp
+++ b/src/occparse/iexpr.cpp
@@ -319,7 +319,7 @@ static int bitintbits(EXPRESSION* node)
 }
 static Optimizer::IMODE* bitint_unary(EXPRESSION* node) 
 {
-    static std::unordered_map<ExpressionNode, const char*> funcs = {{ExpressionNode::uminus_, "___biminus"},
+    static std::unordered_map<ExpressionNode, const char*, EnumClassHash> funcs = {{ExpressionNode::uminus_, "___biminus"},
                                                               {ExpressionNode::compl_, "___bicompl"}
     };
     int b;
@@ -340,7 +340,7 @@ static Optimizer::IMODE* bitint_unary(EXPRESSION* node)
 }
 static Optimizer::IMODE* bitint_binary(EXPRESSION* node) 
 {
-    static std::unordered_map<ExpressionNode, const char*> funcs = {{ExpressionNode::add_, "___biadd"},
+    static std::unordered_map<ExpressionNode, const char*,EnumClassHash> funcs = {{ExpressionNode::add_, "___biadd"},
         {ExpressionNode::sub_, "___bisub"}, {ExpressionNode::and_, "___biand"}, {ExpressionNode::or_, "___bior"}, {
             ExpressionNode::xor_, "___bixor"}, {ExpressionNode::mul_, "___bimul"}, {ExpressionNode::umul_, "___biumul"}, {
             ExpressionNode::div_, "___bidiv"}, {ExpressionNode::udiv_, "___biudiv"}, {ExpressionNode::mod_,

--- a/src/occparse/occparse.cpp
+++ b/src/occparse/occparse.cpp
@@ -119,10 +119,13 @@ void* operator new(size_t aa)
     {
         // If malloc fails and there is a new_handler,
         // call it to try free up memory.
+
+#if __GNUC__ > 4
         std::new_handler nh = std::get_new_handler();
         if (nh)
             nh();
         else
+#endif
             throw std::bad_alloc();
     }
     rv->size = bb;

--- a/src/ocpp/Token.cpp
+++ b/src/ocpp/Token.cpp
@@ -670,19 +670,19 @@ const Token* Tokenizer::Next()
     size_t n = line.find_first_not_of("\t \v");
     line.erase(0, n);
     if (line.empty())
-        currentToken = std::make_unique<EndToken>();
+        currentToken.reset(new EndToken());
     else if (NumericToken::Start(line))
-        currentToken = std::make_unique<NumericToken>(line);
+        currentToken.reset(new NumericToken(line));
     else if (CharacterToken::Start(line))
-        currentToken = std::make_unique<CharacterToken>(line);
+        currentToken.reset(new CharacterToken(line));
     else if (StringToken::Start(line))
-        currentToken = std::make_unique<StringToken>(line);
+        currentToken.reset(new StringToken(line));
     else if (IdentifierToken::Start(line))
-        currentToken = std::make_unique<IdentifierToken>(line, keywordTable, caseInsensitive);
+        currentToken.reset(new IdentifierToken(line, keywordTable, caseInsensitive));
     else if (keywordTable && KeywordToken::Start(line))
-        currentToken = std::make_unique<KeywordToken>(line, keywordTable);
+        currentToken.reset(new KeywordToken(line, keywordTable));
     else
-        currentToken = std::make_unique<ErrorToken>(line);
+        currentToken.reset(new ErrorToken(line));
     return currentToken.get();
 }
 void Tokenizer::Reset(const std::string& Line)

--- a/src/ocpp/ppCond.cpp
+++ b/src/ocpp/ppCond.cpp
@@ -148,7 +148,7 @@ void ppCond::HandleIf(bool val, const std::string& line, int lineno)
         skipping = old->skipping;
     if (current)
         skipList.push_front(std::move(current));
-    current = std::make_unique<skip>();
+    current.reset(new skip());
     current->line = lineno;
     if (skipping)
     {

--- a/src/ocpp/ppCtx.cpp
+++ b/src/ocpp/ppCtx.cpp
@@ -55,7 +55,7 @@ std::string ppCtx::GetId(std::string& line)
 bool ppCtx::push(std::string& line)
 {
     define.Process(line);
-    stack.push_front(std::make_unique<CtxData>());
+    stack.push_front(std::unique_ptr<CtxData>(new CtxData()));
     CtxData* p = stack.front().get();
     p->id = nextId++;
     p->name = GetId(line);

--- a/src/ocpp/ppDefine.cpp
+++ b/src/ocpp/ppDefine.cpp
@@ -54,7 +54,7 @@ ppDefine::Definition& ppDefine::Definition::operator=(const ppDefine::Definition
     value = old.value;
     if (old.argList)
     {
-        argList = std::make_unique<DefinitionArgList>();
+        argList.reset( new DefinitionArgList());
         for (auto&& a : *old.argList)
             argList->push_back(a);
     }
@@ -71,7 +71,7 @@ ppDefine::Definition::Definition(const Definition& old) : Symbol(old.GetName())
     value = old.value;
     if (old.argList)
     {
-        argList = std::make_unique<DefinitionArgList>();
+        argList.reset( new DefinitionArgList());
         for (auto&& a : *old.argList)
             argList->push_back(a);
     }
@@ -325,7 +325,7 @@ void ppDefine::DoDefine(std::string& line, bool caseInsensitive)
             else
             {
                 bool hascomma = true;
-                da = std::make_unique<DefinitionArgList>();
+                da.reset( new DefinitionArgList());
                 bool done = false;
                 while (next->IsIdentifier())
                 {

--- a/src/ocpp/ppExpr.cpp
+++ b/src/ocpp/ppExpr.cpp
@@ -58,7 +58,7 @@ PPINT ppExpr::Eval(std::string& line, bool fromConditional)
     if (fromConditional && expressionHandler)
         return expressionHandler(line);
     floatWarned = false;
-    tokenizer = std::make_unique<Tokenizer>(line, &hash);
+    tokenizer.reset(new Tokenizer(line, &hash));
     token = tokenizer->Next();
     if (!token)
         return 0;

--- a/src/ocpp/ppInclude.cpp
+++ b/src/ocpp/ppInclude.cpp
@@ -170,8 +170,8 @@ void ppInclude::pushFile(const std::string& name, const std::string& errname, bo
         }
         // this next line and the support code have been carefully crafted so that GetRealFile() should return a reference to the
         // cached object.
-        current = std::make_unique<ppFile>(fullname, trigraphs, extendedComment, name, define, *ctx, unsignedchar, dialect, asmpp,
-                                           piper, dirs_traversed);
+        current.reset( new ppFile(fullname, trigraphs, extendedComment, name, define, *ctx, unsignedchar, dialect, asmpp,
+                                           piper, dirs_traversed));
         // if (current)
         if (!current->Open())
         {

--- a/src/ocpp/ppMacro.cpp
+++ b/src/ocpp/ppMacro.cpp
@@ -101,7 +101,7 @@ bool ppMacro::HandleRep(std::string& line)
     }
     else if (n > 0)
     {
-        p = std::make_unique<MacroData>();
+        p.reset(new MacroData());
         p->repsLeft = (int)n;
         p->offset = 0;
         p->id = -1;

--- a/src/ocpp/ppPragma.cpp
+++ b/src/ocpp/ppPragma.cpp
@@ -367,7 +367,7 @@ void ppPragma::HandleFar(Tokenizer& tk)
     // fixme
 }
 
-static std::tuple<std::wstring, const Token*> MunchStrings(Tokenizer& tk)
+static std::pair<std::wstring, const Token*> MunchStrings(Tokenizer& tk)
 {
     std::wstring finalStr;
     const Token* tok;

--- a/src/ocpp/ppPragma.h
+++ b/src/ocpp/ppPragma.h
@@ -320,7 +320,7 @@ class Startups
     }
     ~Startups();
 
-    void Add(std::string& item, int Priority, bool startup) { list[item] = std::make_unique<Properties>(Priority, startup); }
+    void Add(std::string& item, int Priority, bool startup) { list[item].reset( new Properties(Priority, startup)); }
     typedef std::map<std::string, std::unique_ptr<Properties>>::iterator StartupIterator;
     StartupIterator begin() { return list.begin(); }
     StartupIterator end() { return list.end(); }

--- a/src/util/CmdSwitch.cpp
+++ b/src/util/CmdSwitch.cpp
@@ -174,7 +174,7 @@ int CmdSwitchDefine::Parse(const char* data)
     {
         return -1;
     }
-    std::unique_ptr<define> newDefine = std::make_unique<define>();
+    std::unique_ptr<define> newDefine(new define());
     newDefine->name = name;
     if (*data == '=')
     {
@@ -212,7 +212,7 @@ int CmdSwitchFile::Parse(const char* data)
         in.seekg(0, std::ios::end);
         size_t size = in.tellg();
         in.seekg(0, std::ios::beg);
-        std::unique_ptr<char[]> data1 = std::make_unique<char[]>(size + 1);
+        std::unique_ptr<char[]> data1(new char[size + 1]);
         memset(data1.get(), 0, size + 1);
         in.read(data1.get(), size);
         data1[size] = 0;
@@ -226,7 +226,7 @@ void CmdSwitchFile::Dispatch(char* data)
 {
     int max = 10;
     argc = 1;
-    argv = std::make_unique<char*[]>(max);
+    argv.reset(new char*[max]);
     argv[0] = (char*)"";
     while (*data)
     {
@@ -235,7 +235,7 @@ void CmdSwitchFile::Dispatch(char* data)
         {
             max += 10;
             std::unique_ptr<char*[]> p = std::move(argv);
-            argv = std::make_unique<char*[]>(max);
+            argv.reset(new char*[max]);
             memcpy(argv.get(), p.get(), argc * sizeof(char*));
         }
     }

--- a/src/util/xml.cpp
+++ b/src/util/xml.cpp
@@ -223,7 +223,7 @@ bool xmlNode::Read(std::fstream& stream, char v)
         if (isalpha(t) || t == '_')
         {
             stream.putback(t);
-            auto attrib = std::make_unique<xmlAttrib>();
+            std::unique_ptr<xmlAttrib> attrib( new xmlAttrib());
             // if (!attrib)
             //    return false;
             if (!attrib->Read(stream))
@@ -328,7 +328,7 @@ bool xmlNode::Read(std::fstream& stream, char v)
                 }
                 else
                 {
-                    auto node = std::make_unique<xmlNode>();
+                    std::unique_ptr<xmlNode> node(new xmlNode());
                     // if (!node)
                     //    return false;
                     if (!node->Read(stream, t))


### PR DESCRIPTION
Having successfully migrated a C compiler to the ECS backend in the meantime (see https://github.com/rochus-keller/EiGen/tree/master/ecc), I now dare to (hopefully) do the same with OrangeC.

To make my work easier, I have now also migrated orangefront and orangeopt to C++11 so that I can compile them with BUSY and GCC 4.8 on my developer machine. I have successfully tested orangefront with a subset of the ECC testcases and assume that the migration did not introduce any bugs. 

Actually, it only needed a few changes to make it compatible with C++11, and in none of the changed parts did I have the impression that C++14 simplified the code (on the contrary, the code became even shorter with C++11).

I therefore recommend incorporating these changes into your code.