### PR TITLE
Minor removal of evaluating + on strings in logging functions.

### DIFF
--- a/src/omake/Depends.cpp
+++ b/src/omake/Depends.cpp
@@ -25,4 +25,4 @@
 
 #include "Depends.h"
 #include "BasicLogging.h"
-Depends::~Depends() { OrangeC::Utils::BasicLogger::log((int)OrangeC::Utils::VerbosityLevels::VERB_EXTREMEDEBUG + 3, "Depends with goal: " + this->GetGoal() + " is being destructed"); }
+Depends::~Depends() { OrangeC::Utils::BasicLogger::log((int)OrangeC::Utils::VerbosityLevels::VERB_EXTREMEDEBUG + 3, "Depends with goal: ", this->GetGoal(), " is being destructed"); }

--- a/src/omake/Depends.h
+++ b/src/omake/Depends.h
@@ -51,7 +51,7 @@ class Depends
         ignoreResults(false)
     {
         OrangeC::Utils::BasicLogger::log((int)OrangeC::Utils::VerbosityLevels::VERB_EXTREMEDEBUG + 3,
-                                         "Depends with goal: " + this->GetGoal() + " is being destructed");
+                                         "Depends with goal: ", this->GetGoal(), " is being destructed");
     }
     ~Depends();
 

--- a/src/omake/Eval.cpp
+++ b/src/omake/Eval.cpp
@@ -113,11 +113,11 @@ void Eval::Clear()
 
 std::string Eval::Evaluate()
 {
-    OrangeC::Utils::BasicLogger::log((int)OrangeC::Utils::VerbosityLevels::VERB_EXTREMEDEBUG + 3, "Eval::Evaluate called with str: " + str);
+    OrangeC::Utils::BasicLogger::log((int)OrangeC::Utils::VerbosityLevels::VERB_EXTREMEDEBUG + 3, "Eval::Evaluate called with str: ", str);
     std::string rv = ParseMacroLine(str);
     if (expandWildcards)
         rv = wildcardinternal(rv);
-    OrangeC::Utils::BasicLogger::log((int)OrangeC::Utils::VerbosityLevels::VERB_EXTREMEDEBUG + 3, "Eval::Evaluate called with str: " + str);
+    OrangeC::Utils::BasicLogger::log((int)OrangeC::Utils::VerbosityLevels::VERB_EXTREMEDEBUG + 3, "Eval::Evaluate called with str: ", str);
     return rv;
 }
 
@@ -1190,7 +1190,7 @@ std::string Eval::notdir(const std::string& names)
             rv += " ";
         rv += intermed;
     }
-    OrangeC::Utils::BasicLogger::debug("Eval::notdir with Original name: " + names + " evaluated names " + working + " returns: " + rv);
+    OrangeC::Utils::BasicLogger::debug("Eval::notdir with Original name: ", names, " evaluated names ", working, " returns: ", rv);
     return rv;
 }
 
@@ -1290,7 +1290,7 @@ std::string Eval::addprefix(const std::string& arglist)
 
 std::string Eval::wildcard(const std::string& arglist)
 {
-    OrangeC::Utils::BasicLogger::log((int)OrangeC::Utils::VerbosityLevels::VERB_EXTREMEDEBUG + 3, "Called Eval::wildcard with argslist: " + arglist);
+    OrangeC::Utils::BasicLogger::log((int)OrangeC::Utils::VerbosityLevels::VERB_EXTREMEDEBUG + 3, "Called Eval::wildcard with argslist: ", arglist);
 
     std::string names = strip(arglist);
     std::string rv;
@@ -1305,13 +1305,13 @@ std::string Eval::wildcard(const std::string& arglist)
             rv += current;
         }
     }
-    OrangeC::Utils::BasicLogger::log((int)OrangeC::Utils::VerbosityLevels::VERB_EXTREMEDEBUG + 3,"Returning from Eval::wildcard: " + rv);
+    OrangeC::Utils::BasicLogger::log((int)OrangeC::Utils::VerbosityLevels::VERB_EXTREMEDEBUG + 3,"Returning from Eval::wildcard: ", rv);
 
     return rv;
 }
 std::string Eval::wildcardinternal(std::string& names)
 {
-    OrangeC::Utils::BasicLogger::log((int)OrangeC::Utils::VerbosityLevels::VERB_EXTREMEDEBUG + 3,"Called Eval::wildcardinternal with argslist: " + names);
+    OrangeC::Utils::BasicLogger::log((int)OrangeC::Utils::VerbosityLevels::VERB_EXTREMEDEBUG + 3,"Called Eval::wildcardinternal with argslist: ", names);
     CmdFiles files;
     while (!names.empty())
     {
@@ -1325,7 +1325,7 @@ std::string Eval::wildcardinternal(std::string& names)
             rv += " ";
         rv += name;
     }
-    OrangeC::Utils::BasicLogger::log((int)OrangeC::Utils::VerbosityLevels::VERB_EXTREMEDEBUG + 3,"Returning from Eval::wildcardinternal: " + rv);
+    OrangeC::Utils::BasicLogger::log((int)OrangeC::Utils::VerbosityLevels::VERB_EXTREMEDEBUG + 3,"Returning from Eval::wildcardinternal: ", rv);
     return rv;
 }
 
@@ -1492,7 +1492,7 @@ std::string Eval::foreach (const std::string& arglist)
 
 std::string Eval::call(const std::string& arglist)
 {
-    OrangeC::Utils::BasicLogger::log((int)OrangeC::Utils::VerbosityLevels::VERB_EXTREMEDEBUG + 3, "Called Eval::call with argslist: " + arglist);
+    OrangeC::Utils::BasicLogger::log((int)OrangeC::Utils::VerbosityLevels::VERB_EXTREMEDEBUG + 3, "Called Eval::call with argslist: ", arglist);
     std::string sub = arglist;
     std::string args;
     std::string rv;

--- a/src/omake/JobServer.cpp
+++ b/src/omake/JobServer.cpp
@@ -21,15 +21,13 @@ std::shared_ptr<JobServer> JobServer::GetJobServer(int max_jobs)
     int pid = getpid();
     std::string omake_string = "OMAKE";
     std::string combined = omake_string + std::to_string(pid);
-    OrangeC::Utils::BasicLogger::log(5,
-                                     "GetJobServer making new job server: " + combined + " job count: " + std::to_string(max_jobs));
+    OrangeC::Utils::BasicLogger::log(5, "GetJobServer making new job server: ", combined, " job count: ", std::to_string(max_jobs));
     return std::make_shared<WINDOWSJobServer>(combined, max_jobs);
 #else
     int pid = getpid();
     std::string omake_string = "OMAKE";
     std::string combined = omake_string + std::to_string(pid);
-    OrangeC::Utils::BasicLogger::log(5,
-                                     "GetJobServer making new job server: " + combined + " job count: " + std::to_string(max_jobs));
+    OrangeC::Utils::BasicLogger::log(5, "GetJobServer making new job server: ", combined, " job count: ", std::to_string(max_jobs));
 
     return std::make_shared<POSIXJobServer>(combined, max_jobs);
 #endif
@@ -45,8 +43,8 @@ std::shared_ptr<JobServer> JobServer::GetJobServer(const std::string& auth_strin
     {
         std::string new_string = std::string(auth_string.begin() + found + strlen("auth:"), auth_string.end());
         OrangeC::Utils::BasicLogger::log(OrangeC::Utils::VerbosityLevels::VERB_EXTREMEDEBUG,
-                                         "GetJobServer(std::string) auth based, string: " + auth_string +
-                                             " new string: " + new_string);
+                                         "GetJobServer(std::string) auth based, string: ", auth_string,
+                                         " new string: ", new_string);
         return std::make_shared<POSIXJobServer>(new_string);
     }
     else

--- a/src/omake/Runner.cpp
+++ b/src/omake/Runner.cpp
@@ -48,7 +48,7 @@ void Runner::CallRunner(Runner* runner, std::list<std::shared_ptr<RuleList>>* li
 {
     auto retval = runner->RunOne(list, depend, env, keepGoing);
     promise.set_value(retval);
-    OrangeC::Utils::BasicLogger::debug("CallRunner returning from a runner: " + depend->GetGoal());
+    OrangeC::Utils::BasicLogger::debug("CallRunner returning from a runner: ", depend->GetGoal());
 }
 struct future_holding_struct
 {
@@ -124,7 +124,7 @@ int Runner::RunOne(std::list<std::shared_ptr<RuleList>>* ruleStack_in, Depends* 
     {
         std::promise<int> promise;
         workingList.push_back(future_holding_struct(depend->GetGoal(), promise.get_future()));
-        OrangeC::Utils::BasicLogger::debug("RunOne CallRunner Creating a runner: " + i->GetGoal());
+        OrangeC::Utils::BasicLogger::debug("RunOne CallRunner Creating a runner: ", i->GetGoal());
 
         auto thrd = std::thread(CallRunner, this, &ruleStack, i.get(), env, keepGoing, std::move(promise));
         workingThreads.emplace_back(i->GetGoal(), std::move(thrd));

--- a/src/omake/Spawner.cpp
+++ b/src/omake/Spawner.cpp
@@ -80,13 +80,15 @@ static bool HasMake(const std::string& cmd, const std::string& make)
             {
                 m = cmd.find_first_of(" \n\t\r\v", m + 1);
             }
-            if ( m != std::string::npos && m > n)
+            if (m != std::string::npos && m > n)
                 return true;
             // hack for autoconfig texts which use '&& $(MAKE) ...'
             // a more complete solution would look for any bash operator I guess...
-            while (n > 0 && !isspace(cmd[n]) && cmd[n] != '&') n--;
-            while (n > 0 && isspace(cmd[n])) n--;
-            if (n > 1 && cmd[n] == '&' && cmd[n-1] == '&')
+            while (n > 0 && !isspace(cmd[n]) && cmd[n] != '&')
+                n--;
+            while (n > 0 && isspace(cmd[n]))
+                n--;
+            if (n > 1 && cmd[n] == '&' && cmd[n - 1] == '&')
                 return true;
         }
     }
@@ -236,11 +238,12 @@ int Spawner::Run(const std::string& cmdin, bool ignoreErrors, bool silent, bool 
     std::string varname = OS::LookupShellNames();
     if (!OS::IsUnixLikeShell(varname))
     {
-        OrangeC::Utils::BasicLogger::log((int)OrangeC::Utils::VerbosityLevels::VERB_EXTREMEDEBUG + 3, "Command before NormalizeFileName: ", cmdin);
+        OrangeC::Utils::BasicLogger::log((int)OrangeC::Utils::VerbosityLevels::VERB_EXTREMEDEBUG + 3,
+                                         "Command before NormalizeFileName: ", cmdin);
 
         cmd = OS::NormalizeFileName(cmdin);
-        OrangeC::Utils::BasicLogger::log((int)OrangeC::Utils::VerbosityLevels::VERB_EXTREMEDEBUG + 3, "Command after NormalizeFileName: ", cmd);
-
+        OrangeC::Utils::BasicLogger::log((int)OrangeC::Utils::VerbosityLevels::VERB_EXTREMEDEBUG + 3,
+                                         "Command after NormalizeFileName: ", cmd);
     }
     std::string make;
     Variable* v1 = VariableContainer::Instance()->Lookup("MAKE");
@@ -354,8 +357,8 @@ bool Spawner::split(const std::string& cmd)
 }
 std::string Spawner::shell(const std::string& cmd)
 {
-    OrangeC::Utils::BasicLogger::log(OrangeC::Utils::VerbosityLevels::VERB_WARNING,
-                                     OS::JobName() + " is running $(shell " + cmd + " )");
+    OrangeC::Utils::BasicLogger::log(OrangeC::Utils::VerbosityLevels::VERB_WARNING, OS::JobName(), " is running $(shell ", cmd,
+                                     " )");
     std::string rv = OS::SpawnWithRedirect(cmd);
     int n = rv.size();
     while (n && (rv[n - 1] == '\r' || rv[n - 1] == '\n'))

--- a/src/omake/os.cpp
+++ b/src/omake/os.cpp
@@ -933,13 +933,15 @@ std::string OS::SpawnWithRedirect(const std::string command)
             exit_condition = (WIFEXITED(status) || WIFSTOPPED(status));
             if (WIFEXITED(status))
             {
-                OrangeC::Utils::BasicLogger::debug("Process with command: " + command + " exited. ret_wait: " +
-                                                   std::to_string(ret_wait) + " status: " + std::to_string(status));
+                OrangeC::Utils::BasicLogger::debug("Process with command: ", command,
+                                                   " exited. ret_wait: ", std::to_string(ret_wait),
+                                                   " status: ", std::to_string(status));
             }
             if (WIFSTOPPED(status))
             {
-                OrangeC::Utils::BasicLogger::debug("Process with command: " + command + " stopped. ret_wait: " +
-                                                   std::to_string(ret_wait) + " status: " + std::to_string(status));
+                OrangeC::Utils::BasicLogger::debug("Process with command: ", command,
+                                                   " stopped. ret_wait: ", std::to_string(ret_wait),
+                                                   " status: ", std::to_string(status));
             }
             status = WEXITSTATUS(status);
         }
@@ -947,8 +949,8 @@ std::string OS::SpawnWithRedirect(const std::string command)
     } while (!exit_condition);
     close(pipe_cout[0]);
     close(pipe_cout[1]);
-    OrangeC::Utils::BasicLogger::debug("OS::SpawnWithRedirect returning from command: " + command +
-                                       " with status: " + std::to_string(status));
+    OrangeC::Utils::BasicLogger::debug("OS::SpawnWithRedirect returning from command: ", command,
+                                       " with status: ", std::to_string(status));
     return output_str;
 #endif
 }


### PR DESCRIPTION
This is to partially address #1114 
`upstream/master`: 20:7.09
This patch applied: 0:18:41.26
Patch + my work in #1112 after a 2nd build:  0:17:49.36 
~1.2 minutes shaved
Turns out doing a bunch of logic that doesn't get used is wasteful.
I also ran multiple compile sets before this, so if there were any files in the disk-cache it would affect both.
This may be within variance(?) but at the minimum this does clear out a ton of cases where my logging adds unnecessary time.
In theory, if I switch to a set of macro calls that do an inline check before the call I may save some time with all of those logging calls by just not doing a `call` instruction callout whatsoever, but that's an additional effort thing there.
It does appear that my attempt to keep the number of `occparse`s under control is still failing(? this may be because of task manager not clearing them out as they come up, I'd need a better way to verify this.... a global semaphore acting as a counter?)
I did cherry-pick this from my `master` branch in #1112 , so I can drop this and just treat my main branch as the main "run through all the optimizations" branch.