### PR TITLE
Fix issue #1156

### DIFF
--- a/src/occ/occ.cpp
+++ b/src/occ/occ.cpp
@@ -532,7 +532,7 @@ int main(int argc, char* argv[]) MAINTRY
     }
     delete optimizerMem;
     if (rv == 255)  // means don't run the optimizer or backend
-        rv = 0;
+        rv = 1;
     return rv;
 }
 MAINCATCH

--- a/src/occopt/configx86.cpp
+++ b/src/occopt/configx86.cpp
@@ -109,7 +109,8 @@ Executable Mode:
     d - dll                             c = crtdll.dll
     g - windowing                       m = msvcrtdll.dll
     
-Optimization control: OPTIMIZATION_DESCRIPTION Flags: OPTMODULES_DESCRIPTION
+Optimization control:)help" "\n" OPTIMIZATION_DESCRIPTION "Flags:\n" OPTMODULES_DESCRIPTION
+    R"help(
     -fsyntax-only                  compile only, don't produce an output file
     -funsigned-char                'char' type is unsigned
     -std=xxxx                       specify the language standard to use


### PR DESCRIPTION
When a subcommand returns an error code, use an error code to indicate that we encountered an error.
Fixes #1156.